### PR TITLE
Add minimal prometheus exporter support

### DIFF
--- a/kvmd/apps/kvmd/http.py
+++ b/kvmd/apps/kvmd/http.py
@@ -147,6 +147,23 @@ def make_json_exception(err: Exception, status: Optional[int]=None) -> aiohttp.w
     }, status=status)
 
 
+def make_text_response(
+    result: str,
+    status: int=200,
+    set_cookies: Optional[Dict[str, str]]=None,
+) -> aiohttp.web.Response:
+
+    response = aiohttp.web.Response(
+        text=result,
+        status=status,
+        content_type="text/plain",
+    )
+    if set_cookies:
+        for (key, value) in set_cookies.items():
+            response.set_cookie(key, value)
+    return response
+
+
 # =====
 async def get_multipart_field(reader: aiohttp.MultipartReader, name: str) -> aiohttp.BodyPartReader:
     field = await reader.next()


### PR DESCRIPTION
Prometheus https://prometheus.io/ is one of the popular monitoring systems. It pulls service's endpoint to get metrics in a simple text format https://prometheus.io/docs/instrumenting/exposition_formats/

Existing InfoApi was used as it already collecting and exposing system info. There is no sensitive information in it, so, could be exposed w/o auth.

In order to enable Prometheus getting metrics from pikvm following config could be used:

```
scrape_configs:
  - job_name: "pikvm"
    metrics_path: "/api/export/prometheus/metrics"
    static_configs:
    - targets: ["pikvm:8080"]
```

I've tested it using `make run` and Prometheus server and it works fine. Here is a sample output of `/api/metrics`:

```
# TYPE pikvm_temp_cpu gauge
pikvm_temp_cpu 36.511
# TYPE pikvm_temp_gpu gauge
pikvm_temp_gpu 35.0
# TYPE pikvm_throttling_raw_flags gauge
pikvm_throttling_raw_flags 0
# TYPE pikvm_throttling_undervoltage_now gauge
pikvm_throttling_undervoltage_now 0
# TYPE pikvm_throttling_undervoltage_past gauge
pikvm_throttling_undervoltage_past 0
# TYPE pikvm_throttling_freq_capped_now gauge
pikvm_throttling_freq_capped_now 0
# TYPE pikvm_throttling_freq_capped_past gauge
pikvm_throttling_freq_capped_past 0
# TYPE pikvm_throttling_throttled_now gauge
pikvm_throttling_throttled_now 0
# TYPE pikvm_throttling_throttled_past gauge
pikvm_throttling_throttled_past 0
``` 