### PR TITLE
Make KVMD compatible with Python 3.7

### DIFF
--- a/kvmd/aiotools.py
+++ b/kvmd/aiotools.py
@@ -177,5 +177,6 @@ async def run_region_task(
 
     if entered.done():
         return
-    if (exc := task.exception()) is not None:
+    exc = task.exception()
+    if exc is not None:
         raise exc

--- a/kvmd/apps/kvmd/api/auth.py
+++ b/kvmd/apps/kvmd/api/auth.py
@@ -45,7 +45,8 @@ _COOKIE_AUTH_TOKEN = "auth_token"
 
 async def check_request_auth(auth_manager: AuthManager, exposed: HttpExposed, request: Request) -> None:
     if exposed.auth_required and auth_manager.is_auth_enabled():
-        if (user := request.headers.get("X-KVMD-User", "")):
+        user = request.headers.get("X-KVMD-User", "")
+        if user:
             user = valid_user(user)
             passwd = request.headers.get("X-KVMD-Passwd", "")
             set_request_auth_info(request, f"{user} (xhdr)")
@@ -53,7 +54,8 @@ async def check_request_auth(auth_manager: AuthManager, exposed: HttpExposed, re
                 raise ForbiddenError()
             return
 
-        elif (token := request.cookies.get(_COOKIE_AUTH_TOKEN, "")):
+        token = request.cookies.get(_COOKIE_AUTH_TOKEN, "")
+        if token:
             user = auth_manager.check(valid_auth_token(token))
             if not user:
                 set_request_auth_info(request, "- (token)")
@@ -61,7 +63,8 @@ async def check_request_auth(auth_manager: AuthManager, exposed: HttpExposed, re
             set_request_auth_info(request, f"{user} (token)")
             return
 
-        elif (basic_auth := request.headers.get("Authorization", "")):
+        basic_auth = request.headers.get("Authorization", "")
+        if basic_auth:
             if basic_auth[:6].lower() == "basic ":
                 try:
                     (user, passwd) = base64.b64decode(basic_auth[6:]).decode("utf-8").split(":")

--- a/kvmd/apps/kvmd/api/streamer.py
+++ b/kvmd/apps/kvmd/api/streamer.py
@@ -56,11 +56,12 @@ class StreamerApi:
 
     @exposed_http("GET", "/streamer/snapshot")
     async def __take_snapshot_handler(self, request: Request) -> Response:
-        if (snapshot := await self.__streamer.take_snapshot(
+        snapshot = await self.__streamer.take_snapshot(
             save=valid_bool(request.query.get("save", "false")),
             load=valid_bool(request.query.get("load", "false")),
             allow_offline=valid_bool(request.query.get("allow_offline", "false")),
-        )):
+        )
+        if snapshot:
             if valid_bool(request.query.get("preview", "false")):
                 data = await self.__make_preview(
                     snapshot=snapshot,

--- a/kvmd/apps/kvmd/http.py
+++ b/kvmd/apps/kvmd/http.py
@@ -77,8 +77,8 @@ def get_exposed_http(obj: object) -> List[HttpExposed]:
             auth_required=getattr(handler, _HTTP_AUTH_REQUIRED),
             handler=handler,
         )
-        for name in dir(obj)
-        if inspect.ismethod(handler := getattr(obj, name)) and getattr(handler, _HTTP_EXPOSED, False)
+        for handler in [getattr(obj, name) for name in dir(obj)]
+        if inspect.ismethod(handler) and getattr(handler, _HTTP_EXPOSED, False)
     ]
 
 
@@ -107,8 +107,8 @@ def get_exposed_ws(obj: object) -> List[WsExposed]:
             event_type=getattr(handler, _WS_EVENT_TYPE),
             handler=handler,
         )
-        for name in dir(obj)
-        if inspect.ismethod(handler := getattr(obj, name)) and getattr(handler, _WS_EXPOSED, False)
+        for handler in [getattr(obj, name) for name in dir(obj)]
+        if inspect.ismethod(handler) and getattr(handler, _WS_EXPOSED, False)
     ]
 
 

--- a/kvmd/apps/kvmd/info/hw.py
+++ b/kvmd/apps/kvmd/info/hw.py
@@ -109,10 +109,11 @@ class HwInfoSubmanager(BaseInfoSubmanager):
 
     async def __get_throttling(self) -> Optional[Dict]:
         # https://www.raspberrypi.org/forums/viewtopic.php?f=63&t=147781&start=50#p972790
-        if (flags := await self.__parse_vcgencmd(
+        flags = await self.__parse_vcgencmd(
             arg="get_throttled",
             parser=(lambda text: int(text.split("=")[-1].strip(), 16)),
-        )) is not None:
+        )
+        if flags is not None:
             return {
                 "raw_flags": flags,
                 "parsed_flags": {

--- a/kvmd/apps/kvmd/server.py
+++ b/kvmd/apps/kvmd/server.py
@@ -215,7 +215,8 @@ class KvmdServer(HttpServer):  # pylint: disable=too-many-arguments,too-many-ins
             ("desired_fps", valid_stream_fps, None),
             ("resolution", valid_stream_resolution, StreamerResolutionNotSupported),
         ]:
-            if (value := request.query.get(name)):
+            value = request.query.get(name)
+            if (value):
                 if name not in current_params:
                     assert exc_cls is not None, name
                     raise exc_cls()

--- a/kvmd/apps/vnc/rfb/__init__.py
+++ b/kvmd/apps/vnc/rfb/__init__.py
@@ -373,7 +373,7 @@ class RfbClient(RfbClientStream):  # pylint: disable=too-many-instance-attribute
         # JpegCompression may only be used when bits-per-pixel is either 16 or 32
         bits_per_pixel = (await self._read_struct("xxx BB?? HHH BBB xxx"))[0]
         if bits_per_pixel not in [16, 32]:
-            raise RfbError(f"Requested unsupported {bits_per_pixel=} for Tight JPEG; required 16 or 32")
+            raise RfbError(f"Requested unsupported bits_per_pixel={bits_per_pixel} for Tight JPEG; required 16 or 32")
 
     async def __handle_set_encodings(self) -> None:
         encodings_count = (await self._read_struct("x H"))[0]

--- a/kvmd/apps/vnc/rfb/__init__.py
+++ b/kvmd/apps/vnc/rfb/__init__.py
@@ -363,7 +363,8 @@ class RfbClient(RfbClientStream):  # pylint: disable=too-many-instance-attribute
         }
         while True:
             msg_type = await self._read_number("B")
-            if (handler := handlers.get(msg_type)) is not None:
+            handler = handlers.get(msg_type)
+            if handler is not None:
                 await handler()  # type: ignore  # mypy bug
             else:
                 raise RfbError(f"Unknown message type: {msg_type}")

--- a/kvmd/apps/vnc/server.py
+++ b/kvmd/apps/vnc/server.py
@@ -239,7 +239,8 @@ class _Client(RfbClient):  # pylint: disable=too-many-instance-attributes
 
     async def _on_key_event(self, code: int, state: bool) -> None:
         if self.__kvmd_ws:
-            if (web_key := self.__symmap.get(code)) is not None:
+            web_key = self.__symmap.get(code)
+            if web_key is not None:
                 await self.__kvmd_ws.send_key_event(web_key.name, state)
 
     async def _on_pointer_event(self, buttons: Dict[str, bool], wheel: Dict[str, int], move: Dict[str, int]) -> None:

--- a/kvmd/keyboard/keysym.py
+++ b/kvmd/keyboard/keysym.py
@@ -54,7 +54,8 @@ def build_symmap(path: str) -> Dict[int, SymmapWebKey]:
         (path, list(_read_keyboard_layout(path).items())),
     ]:
         for (code, key) in items:
-            if (web_name := AT1_TO_WEB.get(key.code)) is not None:
+            web_name = AT1_TO_WEB.get(key.code)
+            if web_name is not None:
                 if (
                     (web_name in ["ShiftLeft", "ShiftRight"] and key.shift)  # pylint: disable=too-many-boolean-expressions
                     or (web_name in ["AltLeft", "AltRight"] and key.altgr)
@@ -113,7 +114,8 @@ def _read_keyboard_layout(path: str) -> Dict[int, At1Key]:  # Keysym to evdev (a
 
         parts = line.split()
         if len(parts) >= 2:
-            if (x11_code := _resolve_keysym(parts[0])) != 0:
+            x11_code = _resolve_keysym(parts[0])
+            if x11_code != 0:
                 try:
                     at1_code = int(parts[1], 16)
                 except ValueError as err:
@@ -128,7 +130,8 @@ def _read_keyboard_layout(path: str) -> Dict[int, At1Key]:  # Keysym to evdev (a
                     ctrl=("ctrl" in rest),
                 )
 
-                if "addupper" in rest and (x11_code := _resolve_keysym(parts[0].upper())) != 0:
+                x11_code = _resolve_keysym(parts[0].upper())
+                if "addupper" in rest and x11_code != 0:
                     layout[x11_code] = At1Key(
                         code=at1_code,
                         shift=True,

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ def main() -> None:
         classifiers=[
             "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
             "Development Status :: 4 - Beta",
-            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.7",
             "Topic :: System :: Systems Administration",
             "Operating System :: POSIX :: Linux",
             "Intended Audience :: System Administrators",


### PR DESCRIPTION
Using new features provided by Python 3.8 is nice, but there are popular Linux distributions (like Debian / Raspbian) that still use Python 3.7.

Only two 3.8-specific features are used in KVMD:
* assignment expressions using `:=` operator,
* `{variable=}` substitution in f-strings.

This set of changes makes KVMD compatible with Python 3.7 by rewriting its code to not use these features. I tried to do it carefully, without sacrificing readability.

I've tested these changes thoroughly. I have KVMD with these changes working flawlessly on Raspberry Pi 4 with Raspbian.