### PR TITLE
Make kvmd compatible with libgpiod 1.2

### DIFF
--- a/kvmd/plugins/atx/gpio.py
+++ b/kvmd/plugins/atx/gpio.py
@@ -111,10 +111,10 @@ class Plugin(BaseAtx):  # pylint: disable=too-many-instance-attributes
         self.__chip = gpiod.Chip(aiogp.DEVICE_PATH)
 
         self.__power_switch_line = self.__chip.get_line(self.__power_switch_pin)
-        self.__power_switch_line.request("kvmd::atx-gpio::power_switch", gpiod.LINE_REQ_DIR_OUT, default_val=0)
+        self.__power_switch_line.request("kvmd::atx-gpio::power_switch", gpiod.LINE_REQ_DIR_OUT, default_vals=[0])
 
         self.__reset_switch_line = self.__chip.get_line(self.__reset_switch_pin)
-        self.__reset_switch_line.request("kvmd::atx-gpio::reset_switch", gpiod.LINE_REQ_DIR_OUT, default_val=0)
+        self.__reset_switch_line.request("kvmd::atx-gpio::reset_switch", gpiod.LINE_REQ_DIR_OUT, default_vals=[0])
 
     async def get_state(self) -> Dict:
         return {

--- a/kvmd/plugins/hid/serial.py
+++ b/kvmd/plugins/hid/serial.py
@@ -172,7 +172,7 @@ class _Gpio:
             assert self.__reset_line is None
             self.__chip = gpiod.Chip(aiogp.DEVICE_PATH)
             self.__reset_line = self.__chip.get_line(self.__reset_pin)
-            self.__reset_line.request("kvmd::hid-serial::reset", gpiod.LINE_REQ_DIR_OUT, default_val=0)
+            self.__reset_line.request("kvmd::hid-serial::reset", gpiod.LINE_REQ_DIR_OUT, default_vals=[0])
 
     def close(self) -> None:
         if self.__chip:

--- a/kvmd/plugins/msd/relay.py
+++ b/kvmd/plugins/msd/relay.py
@@ -177,10 +177,10 @@ class _Gpio:
         self.__chip = gpiod.Chip(aiogp.DEVICE_PATH)
 
         self.__target_line = self.__chip.get_line(self.__target_pin)
-        self.__target_line.request("kvmd::msd-relay::target", gpiod.LINE_REQ_DIR_OUT, default_val=0)
+        self.__target_line.request("kvmd::msd-relay::target", gpiod.LINE_REQ_DIR_OUT, default_vals=[0])
 
         self.__reset_line = self.__chip.get_line(self.__reset_pin)
-        self.__reset_line.request("kvmd::msd-relay::reset", gpiod.LINE_REQ_DIR_OUT, default_val=0)
+        self.__reset_line.request("kvmd::msd-relay::reset", gpiod.LINE_REQ_DIR_OUT, default_vals=[0])
 
     def close(self) -> None:
         if self.__chip:

--- a/kvmd/plugins/ugpio/gpio.py
+++ b/kvmd/plugins/ugpio/gpio.py
@@ -67,7 +67,7 @@ class Plugin(BaseUserGpioDriver):
         self.__chip = gpiod.Chip(aiogp.DEVICE_PATH)
         for (pin, initial) in self.__output_pins.items():
             line = self.__chip.get_line(pin)
-            line.request("kvmd::ugpio-gpio::outputs", gpiod.LINE_REQ_DIR_OUT, default_val=int(initial or False))
+            line.request("kvmd::ugpio-gpio::outputs", gpiod.LINE_REQ_DIR_OUT, default_vals=[int(initial or False)])
             self.__output_lines[pin] = line
 
     async def run(self) -> None:


### PR DESCRIPTION
The singular `default_val` argument of `gpiod.Line.request()` method was introduced in libgpiod 1.3.

For older versions of libgpiod, `defailt_vals` argument with list value should be used.

This argument is available in newer versions of libgpiod as well for compatibility.

This change is needed for Debian / Raspbian 10 that have libgpiod 1.2.