### PR TITLE
Added missing key on non us keyboards

### DIFF
--- a/hid/src/ps2/keymap.h
+++ b/hid/src/ps2/keymap.h
@@ -144,5 +144,6 @@ INLINE void keymapPs2(uint8_t code, Ps2KeyType *ps2_type, uint8_t *ps2_code) {
 		case 103: *ps2_type = PS2_KEY_TYPE_REG; *ps2_code = 112; return; // KEYPAD_0
 		case 104: *ps2_type = PS2_KEY_TYPE_REG; *ps2_code = 113; return; // KEYPAD_DOT
 		case 105: *ps2_type = PS2_KEY_TYPE_SPEC; *ps2_code = 94; return; // KEY_POWER
+		case 106: *ps2_type = PS2_KEY_TYPE_REG; *ps2_code = 97; return; // KEY_NON_US
 	}
 }

--- a/hid/src/usb/keymap.h
+++ b/hid/src/usb/keymap.h
@@ -134,6 +134,7 @@ INLINE KeyboardKeycode keymapUsb(uint8_t code) {
 		case 103: return KEYPAD_0;
 		case 104: return KEYPAD_DOT;
 		case 105: return KEY_POWER;
+		case 106: return KEY_NON_US;
 		default: return KEY_ERROR_UNDEFINED;
 	}
 }

--- a/keymap.csv
+++ b/keymap.csv
@@ -104,3 +104,4 @@ Numpad9,102,KEYPAD_9,0x61,reg:0x7d,0x49,XK_KP_9
 Numpad0,103,KEYPAD_0,0x62,reg:0x70,0x52,XK_KP_0
 NumpadDecimal,104,KEYPAD_DOT,0x63,reg:0x71,0x53,XK_KP_Decimal
 Power,105,KEY_POWER,0x66,spec:0x5e,0xe05e,XK_XF86_Sleep
+IntlBackslash,106,KEY_NON_US,0x64,reg:0x61,0x56,"^XK_greater,XK_less"

--- a/kvmd/keyboard/mappings.py
+++ b/kvmd/keyboard/mappings.py
@@ -149,6 +149,7 @@ KEYMAP: Dict[str, Key] = {
     "Numpad0": Key(serial=SerialKey(code=103), otg=OtgKey(code=98, is_modifier=False)),
     "NumpadDecimal": Key(serial=SerialKey(code=104), otg=OtgKey(code=99, is_modifier=False)),
     "Power": Key(serial=SerialKey(code=105), otg=OtgKey(code=102, is_modifier=False)),
+    "IntlBackslash": Key(serial=SerialKey(code=106), otg=OtgKey(code=100, is_modifier=False)),
 }
 
 
@@ -293,6 +294,8 @@ X11_TO_AT1 = {
     65456: At1Key(code=82, shift=False),  # XK_KP_0
     65454: At1Key(code=83, shift=False),  # XK_KP_Decimal
     65301: At1Key(code=84, shift=False),  # XK_Sys_Req
+    60: At1Key(code=86, shift=False),  # XK_less
+    62: At1Key(code=86, shift=True),  # XK_greater
     65480: At1Key(code=87, shift=False),  # XK_F11
     65481: At1Key(code=88, shift=False),  # XK_F12
     65421: At1Key(code=57372, shift=False),  # XK_KP_Enter
@@ -402,6 +405,7 @@ AT1_TO_WEB = {
     82: "Numpad0",
     83: "NumpadDecimal",
     84: "PrintScreen",
+    86: "IntlBackslash",
     87: "F11",
     88: "F12",
     57372: "NumpadEnter",

--- a/web/kvm/index.html
+++ b/web/kvm/index.html
@@ -681,8 +681,12 @@
                     </div>
               </div>
               <div class="keypad-row">
-                    <div class="modifier wide-4 left small" data-code="ShiftLeft">
+                    <div class="modifier wide-3 left small" data-code="ShiftLeft">
                       <div class="label"><b>&bull;</b><br>Shift
+                      </div>
+                    </div>
+                    <div class="key small" data-code="IntlBackslash">
+                      <div class="label"> 
                       </div>
                     </div>
                     <div class="key single" data-code="KeyZ">
@@ -725,7 +729,7 @@
                       <div class="label">?<br>/
                       </div>
                     </div>
-                    <div class="modifier wide-4 right small" data-code="ShiftRight">
+                    <div class="modifier wide-3 right small" data-code="ShiftRight">
                       <div class="label"><b>&bull;</b><br>Shift
                       </div>
                     </div>

--- a/web/kvm/window-keyboard.pug
+++ b/web/kvm/window-keyboard.pug
@@ -51,13 +51,14 @@ mixin lamp(cls)
 				+key("Quote") "#[br]'
 				+key("Enter", "wide-3 right small") Enter#[br]&crarr;
 			div(class="keypad-row")
-				+modifier("ShiftLeft", "wide-4 left small") Shift
+				+modifier("ShiftLeft", "wide-3 left small") Shift
+				+key("IntlBackslash", "small") 
 				each key in ["Z", "X", "C", "V", "B", "N", "M"]
 					+key(`Key${key}`, "single") #{key}
 				+key("Comma") &lt;#[br],
 				+key("Period") &gt;#[br].
 				+key("Slash") ?#[br]/
-				+modifier("ShiftRight", "wide-4 right small") Shift
+				+modifier("ShiftRight", "wide-3 right small") Shift
 			div(class="keypad-row")
 				+modifier("ControlLeft", "wide-1 left small") Ctrl
 				+modifier("MetaLeft", "wide-1 left small") Win


### PR DESCRIPTION
Some non us keyboards use an extra key for less, greater and bar (German).

I've added a blank key to the virtual keyboard since i don't know if this key represents anything on a us keyboard.

Tested with otg, hid-usb and hid-ps2