### PR TITLE
Added mapping for AltGr key

### DIFF
--- a/genmap.py
+++ b/genmap.py
@@ -33,6 +33,7 @@ from typing import Optional
 import Xlib.keysymdef.latin1
 import Xlib.keysymdef.miscellany
 import Xlib.keysymdef.xf86
+import Xlib.keysymdef.xkb
 
 import mako.template
 
@@ -74,6 +75,7 @@ def _resolve_keysym(name: str) -> int:
         Xlib.keysymdef.latin1,
         Xlib.keysymdef.miscellany,
         Xlib.keysymdef.xf86,
+        Xlib.keysymdef.xkb,
     ]:
         code = getattr(module, name, None)
         if code is not None:

--- a/keymap.csv
+++ b/keymap.csv
@@ -81,7 +81,7 @@ AltLeft,79,KEY_LEFT_ALT,^0x04,reg:0x11,0x38,XK_Alt_L
 MetaLeft,80,KEY_LEFT_GUI,^0x08,spec:0x1f,0xe05b,XK_Meta_L
 ControlRight,81,KEY_RIGHT_CTRL,^0x10,spec:0x14,0xe01d,XK_Control_R
 ShiftRight,82,KEY_RIGHT_SHIFT,^0x20,reg:0x59,0x36,XK_Shift_R
-AltRight,83,KEY_RIGHT_ALT,^0x40,spec:0x11,0xe038,XK_Alt_R
+AltRight,83,KEY_RIGHT_ALT,^0x40,spec:0x11,0xe038,"XK_Alt_R,XK_ISO_Level3_Shift"
 MetaRight,84,KEY_RIGHT_GUI,^0x80,spec:0x27,0xe05c,XK_Meta_R
 Pause,85,KEY_PAUSE,0x48,pause:0xff,0xe046,XK_Pause
 ScrollLock,86,KEY_SCROLL_LOCK,0x47,reg:0x7e,0x46,XK_Scroll_Lock

--- a/kvmd/keyboard/mappings.py
+++ b/kvmd/keyboard/mappings.py
@@ -299,6 +299,7 @@ X11_TO_AT1 = {
     65421: At1Key(code=57372, shift=False),  # XK_KP_Enter
     65508: At1Key(code=57373, shift=False),  # XK_Control_R
     65455: At1Key(code=57397, shift=False),  # XK_KP_Divide
+    65027: At1Key(code=57400, shift=False),  # XK_ISO_Level3_Shift
     65514: At1Key(code=57400, shift=False),  # XK_Alt_R
     65299: At1Key(code=57414, shift=False),  # XK_Pause
     65360: At1Key(code=57415, shift=False),  # XK_Home


### PR DESCRIPTION
AltGr(same as AltRight on us keyboard) on german keyboard is used as 3rd level shift.
