### PR TITLE
Exclude venv from project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /*kvmd-*.tar.gz
 *.pyc
 *.swp
+/venv/


### PR DESCRIPTION
venv is default suggestion from pycharm to use with this project