### PR TITLE
More web interface spelling fixes + a little improvement

### DIFF
--- a/web/share/js/kvm/atx.js
+++ b/web/share/js/kvm/atx.js
@@ -37,9 +37,15 @@ export function Atx() {
 		$("atx-hdd-led").title = "Disk Activity Led";
 
 		for (let args of [
-			["atx-power-button", "power", "Are you sure to click the power button?"],
-			["atx-power-button-long", "power_long", "Are you sure to perform the long press of the power button?"],
-			["atx-reset-button", "reset", "Are you sure to reboot the server?"],
+			["atx-power-button", "power", "Are you sure you want to press the power button?"],
+			["atx-power-button-long", "power_long", `
+				Are you sure you want to long press the power button?<br>
+				(Warning! This could cause data loss on the server.)
+			`],
+			["atx-reset-button", "reset", `
+				Are you sure you want to press the reset button?<br>
+				(Warning! This could case data loss on the server.)
+			`],
 		]) {
 			tools.setOnClick($(args[0]), () => __clickButton(args[1], args[2]));
 		}

--- a/web/share/js/kvm/gpio.js
+++ b/web/share/js/kvm/gpio.js
@@ -123,7 +123,7 @@ export function Gpio() {
 			`;
 		} else if (item.type === "output") {
 			let controls = [];
-			let confirm = (item.confirm ? "Are you sure to act this control?" : "");
+			let confirm = (item.confirm ? "Are you sure you want to perform this action?" : "");
 			if (item.scheme["switch"]) {
 				controls.push(`
 					<td><div class="switch-box">

--- a/web/share/js/kvm/hid.js
+++ b/web/share/js/kvm/hid.js
@@ -196,10 +196,10 @@ export function Hid() {
 	var __clickPasteAsKeysButton = function() {
 		let text = $("hid-pak-text").value.replace(/[^\x00-\x7F]/g, "");  // eslint-disable-line no-control-regex
 		if (text) {
-			let confirm_msg = `
-				You're going to paste ${text.length} characters.<br>
-				Are you sure you want to continue?
-			`;
+			let confirm_msg = text.length !== 1 ?
+				`You're going to paste ${text.length} characters.<br>` :
+				`You're going to paste ${text.length} character.<br>`;
+			confirm_msg += "Are you sure you want to continue?";
 
 			wm.confirm(confirm_msg).then(function(ok) {
 				if (ok) {

--- a/web/share/js/kvm/session.js
+++ b/web/share/js/kvm/session.js
@@ -190,6 +190,7 @@ export function Session() {
 					__ws.onerror = __wsErrorHandler;
 					__ws.onclose = __wsCloseHandler;
 				} else if (http.status === 401 || http.status === 403) {
+					window.onbeforeunload = () => null;
 					wm.error("Unexpected logout occured, please login again").then(function() {
 						document.location.href = "/login";
 					});


### PR DESCRIPTION
Came across a few more spelling errors in the web interface and fixed them.

Also updated the paste dialog to change depending on whether there's 1 or 0,2+ characters.

Also disabled the warning dialog when leaving the page if an unexpected logout has occurred. It was a little annoying to me when I was messing with my build and kept restarting the server which showed the prompt but still had the browser warning.