### PR TITLE
Implementing X509Plain VeNCrypt security type 262 in place of TLSPlai…

### DIFF
--- a/kvmd/apps/vnc/rfb/__init__.py
+++ b/kvmd/apps/vnc/rfb/__init__.py
@@ -41,6 +41,7 @@ from .encodings import RfbClientEncodings
 
 from .crypto import rfb_make_challenge
 from .crypto import rfb_encrypt_challenge
+from .crypto import create_self_signed_cert_if_nonexistent, key_file_name, cert_file_name
 
 from .stream import RfbClientStream
 
@@ -248,7 +249,7 @@ class RfbClient(RfbClientStream):  # pylint: disable=too-many-instance-attribute
         else:
             auth_types = {256: ("VeNCrypt/Plain", False, self.__handshake_security_vencrypt_userpass)}
             if self.__tls_ciphers:
-                auth_types[259] = ("VeNCrypt/TLSPlain", True, self.__handshake_security_vencrypt_userpass)
+                auth_types[262] = ("VeNCrypt/X509Plain", True, self.__handshake_security_vencrypt_userpass)
             if self.__vnc_passwds:
                 # Vinagre не умеет работать с VNC Auth через VeNCrypt, но это его проблемы,
                 # так как он своеобразно трактует рекомендации VeNCrypt.
@@ -271,6 +272,8 @@ class RfbClient(RfbClientStream):  # pylint: disable=too-many-instance-attribute
             assert self.__tls_ciphers, (self.__tls_ciphers, auth_name, tls, handler)
             await self._write_struct("B", 1)  # Ack
             ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            create_self_signed_cert_if_nonexistent(key_file_name, cert_file_name)
+            ssl_context.load_cert_chain(keyfile=key_file_name, certfile=cert_file_name)
             ssl_context.set_ciphers(self.__tls_ciphers)
             await self._start_tls(ssl_context, self.__tls_timeout)
 


### PR DESCRIPTION
…n security type 259.

This is a fix for both bVNC on iOS and for devices that do not support Anonymous Diffie
Hellman ciphers (e.g. Android past API 23).

It provides a mechanism for verifying and approving the identity of the server and ensuring
subsequent connections to the same server are not under MITM attack.