### PR TITLE
Make kvmd webui available via IPv6

### DIFF
--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -38,12 +38,14 @@ http {
 
 #PROD	server {
 #PROD		listen 80;
+#PROD		listen [::]:80;
 #PROD		server_name localhost;
 #PROD		return 301 https://$host$request_uri;
 #PROD	}
 
 	server {
 #PROD		listen 443 ssl http2;
+#PROD		listen [::]:443 ssl http2;
 		server_name localhost;
 #PROD		include /etc/kvmd/nginx/ssl.conf;
 


### PR DESCRIPTION
nginx only binds an IPv4 socket, if the listen option is specified
without [::]. There are two possibilites to fix this issue.

Either the listen option can be specified using only [::], and
additionally including ipv6only=off. This makes nginx bind an IPv6
socket which is also able to handle IPv4 connections.

Or the listen option can be specified twice, one with [::] and one
without. This makes nginx bind two independent sockets.

If the first option is chosen, IPv4 addresses are mapped into the IPv6
address space, which might break scripts, filters, etc.
So, for now, the second option is chosen.