### PR TITLE
Fix /etc/kvmd/{nginx,vnc}/ssl directory creation

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -121,8 +121,8 @@ package_kvmd() {
 	chmod 750 "$_cfg_default/os/sudoers"
 	chmod 400 "$_cfg_default/os/sudoers"/*
 
-	mkdir -p "$pkgdir/etc/kvmd/{nginx,vnc}/ssl"
-	chmod 755 "$pkgdir/etc/kvmd/{nginx,vnc}/ssl"
+	mkdir -p "$pkgdir/etc/kvmd/"{nginx,vnc}"/ssl"
+	chmod 755 "$pkgdir/etc/kvmd/"{nginx,vnc}"/ssl"
 	install -Dm444 -t "$pkgdir/etc/kvmd/nginx" "$_cfg_default/nginx"/*.conf
 	chmod 644 "$pkgdir/etc/kvmd/nginx/nginx.conf"
 


### PR DESCRIPTION
It appears that using quotes when doing brace expansion doesn't work as expected:

[root@pikvm-zerow tmp]# mkdir -p -v "./etc/kvmd/{nginx,vnc}/ssl"
mkdir: created directory './etc'
mkdir: created directory './etc/kvmd'
mkdir: created directory './etc/kvmd/{nginx,vnc}'
mkdir: created directory './etc/kvmd/{nginx,vnc}/ssl'

I believe the desired behavior is the following:

[root@pikvm-zerow tmp]# mkdir -p -v "./etc/kvmd/"{nginx,vnc}"/ssl"
mkdir: created directory './etc/kvmd/nginx'
mkdir: created directory './etc/kvmd/nginx/ssl'
mkdir: created directory './etc/kvmd/vnc'
mkdir: created directory './etc/kvmd/vnc/ssl'

I think the same change would also need to be made to https://github.com/pikvm/packages/blob/master/packages/kvmd/PKGBUILD which I can update if this is acceptable.

This proposed change fixes this issue.