### PR TITLE
fix socket timeout/zero based issues in tesmart

### DIFF
--- a/kvmd/plugins/ugpio/tesmart.py
+++ b/kvmd/plugins/ugpio/tesmart.py
@@ -80,12 +80,12 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
         }
 
     def register_input(self, pin: int, debounce: float) -> None:
-        if not (0 < pin < 16):
+        if not (0 <= pin < 16):
             raise RuntimeError(f"Unsupported port number: {pin}")
         _ = debounce
 
     def register_output(self, pin: int, initial: Optional[bool]) -> None:
-        if not (0 < pin < 16):
+        if not (0 <= pin < 16):
             raise RuntimeError(f"Unsupported port number: {pin}")
         _ = initial
 
@@ -112,7 +112,7 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
 
     async def write(self, pin: int, state: bool) -> None:
         if state:
-            await self.__send_command(b"\x01%.2x" % (pin - 1))
+            await self.__send_command("{:c}{:c}".format(1, pin + 1).encode())
             await self.__update_notifier.notify()
             await asyncio.sleep(self.__switch_delay)  # Slowdown
 
@@ -136,7 +136,8 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
             try:
                 (reader, writer) = await asyncio.open_connection(self.__host, self.__port)
                 sock = writer.get_extra_info("socket")
-                sock.settimeout(self.__timeout)
+#                sock.settimeout(self.__timeout)
+                sock.settimeout(0)
             except Exception as err:
                 get_logger(0).error("Can't connect to Tesmart KVM [%s]:%d: %s",
                                     self.__host, self.__port, tools.efmt(err))


### PR DESCRIPTION
Minor changes in tesmart.py testing on switch:
* Was getting an error that only a 0 timeout is allowed on transport sockets -- also I think making it 0 makes it non-blocking
* Made everything 0 based -- was only accepting ports 1-15 as written. I think this deserves some consideration, as it is confusing to create your override.yaml file saying that what you have in HDMI switch 5 needs to be configured as pin 4.
* When 0 based, you need to add 1 to the write command -- the tesmart "API" is zero based on read and 1 based on write. It was subtracting 1 on write, which is never correct.