### PR TITLE
Feature/ctrl in combinations

### DIFF
--- a/web/kvm/index.html
+++ b/web/kvm/index.html
@@ -226,6 +226,15 @@
                 </div>
               </td>
             </tr>
+            <tr>
+              <td>Ctrl combination's detect:</td>
+              <td align="right">
+                <div class="switch-box">
+                  <input type="checkbox" id="hid-ctrl-combinations-switch">
+                  <label for="hid-ctrl-combinations-switch"><span class="switch-inner"></span><span class="switch"></span></label>
+                </div>
+              </td>
+            </tr>
           </table>
           <hr>
           <div class="buttons buttons-row">

--- a/web/kvm/navbar-system.pug
+++ b/web/kvm/navbar-system.pug
@@ -72,6 +72,8 @@ li(class="right")
 						label(for="gpio-switch-__v3_usb_breaker__")
 							span(class="switch-inner")
 							span(class="switch")
+			tr
+				+menu_switch_notable("hid-ctrl-combinations-switch", "Ctrl combination's detect:", true, false)
 		hr
 		div(class="buttons buttons-row")
 			button(data-force-hide-menu data-show-window="keyboard-window" class="row50") &bull; Show keyboard

--- a/web/share/js/kvm/keyboard.js
+++ b/web/share/js/kvm/keyboard.js
@@ -59,6 +59,18 @@ export function Keyboard(__recordWsEvent) {
 			tools.info("Keyboard: enabled Fix-Mac-CMD");
 			__fix_mac_cmd = true;
 		}
+
+		/*restore state of checkboxex and function to save theirs state*/
+		$$$('table.kv tr:not(.feature-disabled) input[type=checkbox]').forEach(function (i) {
+			let cookie = tools.getCookie(i.id);
+			if (cookie) {
+				i.checked = cookie == 1 ? true : false;
+			}
+			i.onchange = function () {
+				let state = i.checked == true ? 1 : 0;
+				document.cookie = i.id + "=" + state;
+			}
+		})
 	};
 
 	/************************************************************************/
@@ -137,6 +149,9 @@ export function Keyboard(__recordWsEvent) {
 		if (!event.repeat) {
 			// https://bugs.chromium.org/p/chromium/issues/detail?id=28089
 			// https://bugzilla.mozilla.org/show_bug.cgi?id=1299553
+			if($("hid-ctrl-combinations-switch").checked && event.ctrlKey){
+			    __keypad.emit("ControlLeft", true, __fix_mac_cmd);
+			}
 			__keypad.emit(event.code, state, __fix_mac_cmd);
 		}
 	};


### PR DESCRIPTION
Added:
- an ability to catch combinations of keys like CTRL-C in web interface (tested for Chrome/Chromium in Ubuntu 18.04).
- switch to turn off the ability to catch ctrl combinations
- saving of switches' statuses (for all, not only for ctrl combinations) in cookies.