### PR TITLE
Option for use of create_subprocess_shell in run_process

### DIFF
--- a/kvmd/apps/__init__.py
+++ b/kvmd/apps/__init__.py
@@ -445,6 +445,7 @@ def _get_config_scheme() -> Dict:
                 "cmd":        Option(["/bin/true"], type=valid_command),
                 "cmd_remove": Option([], type=valid_options),
                 "cmd_append": Option([], type=valid_options),
+                "use_shell":  Option(False, type=valid_bool),
             },
 
             "snapshot": {

--- a/kvmd/apps/kvmd/streamer.py
+++ b/kvmd/apps/kvmd/streamer.py
@@ -163,6 +163,7 @@ class Streamer:  # pylint: disable=too-many-instance-attributes
         cmd: List[str],
         cmd_remove: List[str],
         cmd_append: List[str],
+        use_shell: bool,
 
         **params_kwargs: Any,
     ) -> None:
@@ -180,6 +181,7 @@ class Streamer:  # pylint: disable=too-many-instance-attributes
         self.__process_name_prefix = process_name_prefix
 
         self.__cmd = tools.build_cmd(cmd, cmd_remove, cmd_append)
+        self.__use_shell = use_shell
 
         self.__params = _StreamerParams(**params_kwargs)
 
@@ -431,7 +433,7 @@ class Streamer:  # pylint: disable=too-many-instance-attributes
             )
             for part in self.__cmd
         ]
-        self.__streamer_proc = await aioproc.run_process(cmd)
+        self.__streamer_proc = await aioproc.run_process(cmd, use_shell = self.__use_shell)
         get_logger(0).info("Started streamer pid=%d: %s", self.__streamer_proc.pid, cmd)
 
     async def __kill_streamer_proc(self) -> None:


### PR DESCRIPTION
Add an option to streamer configuration named 'use_shell' which allows us to use create_subprocess_shell instead of create_subprocess_exec in run_process.

This is useful when we want to run a streamer cmd that involves piping the output of one program to another program - e.g., using ffmpeg or gstreamer in conjunction with another program to get h264 frames to janus via memsink/etc.

There are also changes to kill_process, as otherwise the only program that would be killed when use_shell=True would be the top-level shell, with the children process continuing to run. I tried to preserve the behavior/logic for when there is only a single process to be the exact same, though I'll admit I didn't 100% follow the logic.