### PR TITLE
only show keyboard message on homepage when relevant

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -73,15 +73,17 @@
         <div id="apps-box">
           <h4>Loading ...</h4>
         </div>
-        <hr>
-        <p class="text">
-          Please note that when you are working with a KVM session or another application that captures the keyboard,
-          you can't use some keyboard shortcuts such as Ctrl+Alt+Del (which will be caught by your OS) or Ctrl+W (caught by your browser).
-        </p>
-        <p class="text">To override this limitation you can use <a target="_blank" href="https://google.com/chrome">Google Chrome</a>
-          or <a target="_blank" href="https://chromium.org/Home">Chromium</a> in application mode.
-        </p>
-        <div class="code" id="app-text"></div>
+        <div class="keyboard-warning">
+          <hr>
+          <p class="text">
+            Please note that when you are working with a KVM session or another application that captures the keyboard,
+            you can't use some keyboard shortcuts such as Ctrl+Alt+Del (which will be caught by your OS) or Ctrl+W (caught by your browser).
+          </p>
+          <p class="text">To override this limitation you can use <a target="_blank" href="https://google.com/chrome">Google Chrome</a>
+            or <a target="_blank" href="https://chromium.org/Home">Chromium</a> in application mode.
+          </p>
+          <div class="code" id="app-text"></div>
+        </div>
         <hr>
         <p class="text">
           Full documentation, the source code, and the legal information

--- a/web/index.pug
+++ b/web/index.pug
@@ -27,14 +27,15 @@ block start
 	div(id="apps-box")
 		h4 Loading ...
 
-	hr
+	div(class="keyboard-warning")
+		hr
+		p(class="text")
+			| Please note that when you are working with a KVM session or another application that captures the keyboard,
+			| you can't use some keyboard shortcuts such as Ctrl+Alt+Del (which will be caught by your OS) or Ctrl+W (caught by your browser).
 	p(class="text")
-		| Please note that when you are working with a KVM session or another application that captures the keyboard,
-		| you can't use some keyboard shortcuts such as Ctrl+Alt+Del (which will be caught by your OS) or Ctrl+W (caught by your browser).
-	p(class="text")
-		| To override this limitation you can use #[a(target="_blank" href="https://google.com/chrome") Google Chrome]
-		| or #[a(target="_blank" href="https://chromium.org/Home") Chromium] in application mode.
-	div(id="app-text" class="code")
+			| To override this limitation you can use #[a(target="_blank" href="https://google.com/chrome") Google Chrome]
+			| or #[a(target="_blank" href="https://chromium.org/Home") Chromium] in application mode.
+		div(id="app-text" class="code")
 
 	hr
 	p(class="text")

--- a/web/share/css/index/index.css
+++ b/web/share/css/index/index.css
@@ -89,3 +89,10 @@ tr.server {
 	font-weight: bold;
 	font-family: monospace;
 }
+
+@media all and (display-mode: standalone) {
+	div.keyboard-warning {
+		display: none;
+	}
+}
+


### PR DESCRIPTION
this will hide the message when the app is running in the standalone mode being recommended