### PR TITLE
Update kvmd-bootconfig

### DIFF
--- a/scripts/kvmd-bootconfig
+++ b/scripts/kvmd-bootconfig
@@ -135,8 +135,9 @@ fi
 
 
 # ========== Custom scripts ==========
+mkdir -p /boot/kvmd-bootconfig.d
 for script in `ls /etc/kvmd/bootconfig.d | sort`; do
-	/etc/kvmd/bootconfig.d/"$script" || true
+	/boot/kvmd-bootconfig.d/"$script" || true
 done
 
 


### PR DESCRIPTION
Check for custom scripts inside /boot/kvmd-bootconfig.d directory since /boot is accessible by any client to allow users to drop custom scripts they want to run at boot.