### PR TITLE
RNDIS Version 5 for Windows XP, automatic driver load on Windows using ncm

### DIFF
--- a/kvmd/apps/otg/__init__.py
+++ b/kvmd/apps/otg/__init__.py
@@ -133,6 +133,12 @@ def _create_ethernet(gadget_path: str, config_path: str, driver: str, host_mac: 
         _write(join(gadget_path, "os_desc/b_vendor_code"), "0xCD")
         _write(join(gadget_path, "os_desc/qw_sign"), "MSFT100")
         _symlink(config_path, join(gadget_path, "os_desc/c.1"))
+    if driver == "ncm":
+        _write(join(func_path, "os_desc/interface.ncm/compatible_id"), "WINNCM")
+        _write(join(gadget_path, "os_desc/use"), "1")
+        _write(join(gadget_path, "os_desc/b_vendor_code"), "0xCD")
+        _write(join(gadget_path, "os_desc/qw_sign"), "MSFT100")
+        _symlink(config_path, join(gadget_path, "os_desc/c.1"))
     _symlink(func_path, join(config_path, f"{drv}.usb0"))
 
 
@@ -192,10 +198,12 @@ def _cmd_start(config: Section) -> None:  # pylint: disable=too-many-statements
 
     _write(join(gadget_path, "idVendor"), f"0x{config.otg.vendor_id:04X}")
     _write(join(gadget_path, "idProduct"), f"0x{config.otg.product_id:04X}")
-    # bcdDevaev should be incremented any time there are breaking changes
+    # bcdDevice should be incremented any time there are breaking changes
     # to this script so that the host OS sees it as a new device
     # and re-enumerates everything rather than relying on cached values.
-    if config.otg.devices.ethernet.enabled and config.otg.devices.ethernet.driver == "rndis":
+    if config.otg.devices.ethernet.enabled and config.otg.devices.ethernet.driver == "ncm":
+        _write(join(gadget_path, "bcdDevice"), "0x0102")
+    elif config.otg.devices.ethernet.enabled and config.otg.devices.ethernet.driver == "rndis":
         _write(join(gadget_path, "bcdDevice"), "0x0101")
     else:
         _write(join(gadget_path, "bcdDevice"), "0x0100")

--- a/kvmd/apps/otg/__init__.py
+++ b/kvmd/apps/otg/__init__.py
@@ -113,7 +113,10 @@ def _create_serial(gadget_path: str, config_path: str) -> None:
 def _create_ethernet(gadget_path: str, config_path: str, driver: str, host_mac: str, kvm_mac: str) -> None:
     if host_mac and kvm_mac and host_mac == kvm_mac:
         raise RuntimeError("Ethernet host_mac should not be equal to kvm_mac")
-    func_path = join(gadget_path, f"functions/{driver}.usb0")
+    drv = driver
+    if driver == "rndis5":
+        drv = "rndis"
+    func_path = join(gadget_path, f"functions/{drv}.usb0")
     _mkdir(func_path)
     if host_mac:
         _write(join(func_path, "host_addr"), host_mac)
@@ -130,7 +133,7 @@ def _create_ethernet(gadget_path: str, config_path: str, driver: str, host_mac: 
         _write(join(gadget_path, "os_desc/b_vendor_code"), "0xCD")
         _write(join(gadget_path, "os_desc/qw_sign"), "MSFT100")
         _symlink(config_path, join(gadget_path, "os_desc/c.1"))
-    _symlink(func_path, join(config_path, f"{driver}.usb0"))
+    _symlink(func_path, join(config_path, f"{drv}.usb0"))
 
 
 def _create_hid(gadget_path: str, config_path: str, instance: int, remote_wakeup: bool, hid: Hid) -> None:

--- a/kvmd/apps/otgnet/__init__.py
+++ b/kvmd/apps/otgnet/__init__.py
@@ -173,10 +173,13 @@ class _Service:  # pylint: disable=too-many-instance-attributes
 
     def __find_iface(self) -> str:
         logger = get_logger()
+        drv = self.__driver
+        if self.__driver == "rndis5":
+            drv = "rndis"
         path = env.SYSFS_PREFIX + os.path.join(
             "/sys/kernel/config/usb_gadget",
             self.__gadget,
-            f"functions/{self.__driver}.usb0/ifname",
+            f"functions/{drv}.usb0/ifname",
         )
         logger.info("Using OTG gadget %r ...", self.__gadget)
         with open(path) as iface_file:

--- a/kvmd/validators/hw.py
+++ b/kvmd/validators/hw.py
@@ -55,4 +55,4 @@ def valid_otg_id(arg: Any) -> int:
 
 
 def valid_otg_ethernet(arg: Any) -> str:
-    return check_string_in_list(arg, "OTG Ethernet driver", ["ecm", "eem", "ncm", "rndis"])
+    return check_string_in_list(arg, "OTG Ethernet driver", ["ecm", "eem", "ncm", "rndis", "rndis5"])


### PR DESCRIPTION
rndis5 can by used with Windows XP and later. 
Manual driver installation is required. https://github.com/mfunkey/pikvm/blob/usbeth/docs/driver/win/pikvm-rndis5.inf
