### PR TITLE
Fix kvmd-nginx reload.

### DIFF
--- a/configs/os/services/kvmd-nginx.service
+++ b/configs/os/services/kvmd-nginx.service
@@ -9,7 +9,7 @@ PrivateDevices=yes
 SyslogLevel=err
 
 ExecStart=/usr/sbin/nginx -p /etc/kvmd/nginx -c /etc/kvmd/nginx/nginx.conf -g 'pid /run/kvmd/nginx.pid; user kvmd-nginx; error_log stderr;'
-ExecReload=/usr/sbin/nginx -s reload -p /etc/kvmd/nginx -c /etc/kvmd/nginx/nginx.conf
+ExecReload=/usr/sbin/nginx -s reload -p /etc/kvmd/nginx -c /etc/kvmd/nginx/nginx.conf -g 'pid /run/kvmd/nginx.pid; user kvmd-nginx; error_log stderr;'
 KillSignal=SIGQUIT
 KillMode=mixed
 TimeoutStopSec=3


### PR DESCRIPTION
Currently, a `systemctl reload kvmd-nginx` fails:
```
[root@pikvm kvmd-webterm]# systemctl reload kvmd-nginx
Job for kvmd-nginx.service failed.
See "systemctl status kvmd-nginx.service" and "journalctl -xeu kvmd-nginx.service" for details.
[root@pikvm kvmd-webterm]# systemctl status kvmd-nginx
* kvmd-nginx.service - PiKVM - HTTP entrypoint
     Loaded: loaded (/usr/lib/systemd/system/kvmd-nginx.service; enabled; vendor preset: disabled)
     Active: active (running) since Sun 2022-03-20 21:49:29 MSK; 7h ago
    Process: 17967 ExecReload=/usr/sbin/nginx -s reload -p /etc/kvmd/nginx -c /etc/kvmd/nginx/nginx.conf (code=exited, status=1/FAILURE)
   Main PID: 425 (nginx)
      Tasks: 6 (limit: 4915)
        CPU: 6.411s
     CGroup: /system.slice/kvmd-nginx.service
             |-  425 "nginx: master process /usr/sbin/nginx -p /etc/kvmd/nginx -c /etc/kvmd/nginx/nginx.conf -g pid /run/kvmd/nginx.pid; user kvmd-nginx; error_log st>
             |-  428 "nginx: worker process is shutting down"
             |-17459 "nginx: worker process"
             |-17460 "nginx: worker process"
             |-17461 "nginx: worker process"
             `-17462 "nginx: worker process"

Mar 21 05:12:06 pikvm systemd[1]: kvmd-nginx.service: Control process exited, code=exited, status=1/FAILURE
Mar 21 05:12:06 pikvm systemd[1]: Reload failed for PiKVM - HTTP entrypoint.
Mar 21 05:12:22 pikvm systemd[1]: Reloading PiKVM - HTTP entrypoint...
Mar 21 05:12:22 pikvm nginx[17451]: 2022/03/21 05:12:22 [notice] 17451#17451: signal process started
Mar 21 05:12:22 pikvm systemd[1]: Reloaded PiKVM - HTTP entrypoint.
Mar 21 05:24:38 pikvm systemd[1]: Reloading PiKVM - HTTP entrypoint...
Mar 21 05:24:39 pikvm nginx[17967]: 2022/03/21 05:24:38 [notice] 17967#17967: signal process started
Mar 21 05:24:39 pikvm nginx[17967]: 2022/03/21 05:24:38 [error] 17967#17967: open() "/run/nginx.pid" failed (2: No such file or directory)
Mar 21 05:24:39 pikvm systemd[1]: kvmd-nginx.service: Control process exited, code=exited, status=1/FAILURE
Mar 21 05:24:39 pikvm systemd[1]: Reload failed for PiKVM - HTTP entrypoint.
```

Ensuring the ExecReload command has the same global parameters as the ExecStart command fixes this:
```
[root@pikvm kvmd-webterm]# systemctl reload kvmd-nginx
[root@pikvm kvmd-webterm]# echo $?
0
```