### PR TITLE
fix video pixel-imperfection

### DIFF
--- a/web/share/css/kvm/stream.css
+++ b/web/share/css/kvm/stream.css
@@ -55,7 +55,7 @@ div#stream-box {
 	object-fit: contain;
 	position: relative;
 	display: inline-block;
-	border: var(--border-window-default-thin);
+	border: 0px;
 }
 div.stream-box-offline {
 	-webkit-filter: grayscale(100%) brightness(75%) sepia(75%);

--- a/web/share/css/kvm/stream.css
+++ b/web/share/css/kvm/stream.css
@@ -55,7 +55,8 @@ div#stream-box {
 	object-fit: contain;
 	position: relative;
 	display: inline-block;
-	border: 0px;
+	border: var(--border-window-default-thin);
+	margin: -1px -1px -1px -1px;
 }
 div.stream-box-offline {
 	-webkit-filter: grayscale(100%) brightness(75%) sepia(75%);


### PR DESCRIPTION
fix video pixel-imperfection by taking out 1px worth of internal padding, which inadvertently causing video stream resolution to swell at default(native) resolution

fixes [https://github.com/pikvm/pikvm/issues/599](url)