### PR TITLE
Support for driving TESmart KVMs by RS-232

### DIFF
--- a/kvmd/plugins/ugpio/tesmart.py
+++ b/kvmd/plugins/ugpio/tesmart.py
@@ -21,6 +21,12 @@
 
 
 import asyncio
+
+# At present this requires building a package from AUR:
+# https://aur.archlinux.org/packages/python-pyserial-asyncio
+# https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages
+import serial_asyncio
+
 import functools
 
 from typing import Tuple
@@ -41,6 +47,8 @@ from ...validators.basic import valid_float_f0
 from ...validators.basic import valid_float_f01
 from ...validators.net import valid_ip_or_host
 from ...validators.net import valid_port
+from ...validators.os import valid_abs_path
+from ...validators.hw import valid_tty_speed
 
 from . import BaseUserGpioDriver
 from . import GpioDriverOfflineError
@@ -53,8 +61,11 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
         instance_name: str,
         notifier: aiotools.AioNotifier,
 
+        mode: int,
         host: str,
         port: int,
+        device_path: str,
+        speed: int,
         timeout: float,
         switch_delay: float,
         state_poll: float,
@@ -62,8 +73,11 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
 
         super().__init__(instance_name, notifier)
 
+        self.__mode = mode
         self.__host = host
         self.__port = port
+        self.__device_path = device_path
+        self.__speed = speed
         self.__timeout = timeout
         self.__switch_delay = switch_delay
         self.__state_poll = state_poll
@@ -76,8 +90,11 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
     @classmethod
     def get_plugin_options(cls) -> Dict:
         return {
+            "mode":         Option(1,    type=functools.partial(valid_number, min=1, max=2)),
             "host":         Option("",   type=valid_ip_or_host),
             "port":         Option(5000, type=valid_port),
+            "device":       Option("",   type=valid_abs_path, unpack_as="device_path"),
+            "speed":        Option(9600, type=valid_tty_speed),
             "timeout":      Option(5.0,  type=valid_float_f01),
             "switch_delay": Option(1.0,  type=valid_float_f0),
             "state_poll":   Option(10.0, type=valid_float_f01),
@@ -85,19 +102,19 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
 
     @classmethod
     def get_pin_validator(cls) -> Callable[[Any], Any]:
-        return functools.partial(valid_number, min=0, max=15, name="TESmart channel")
+        return functools.partial(valid_number, min=1, max=16, name="TESmart channel")
 
     async def run(self) -> None:
         prev_active = -2
         while True:
-            await self.__update_notifier.wait(self.__state_poll)
             try:
-                self.__active = await self.__send_command(b"\x10\x00")
+                self.__active = int(await self.__send_command(b"\x10\x00"))+1
             except Exception:
                 pass
             if self.__active != prev_active:
                 await self._notifier.notify()
                 prev_active = self.__active
+            await self.__update_notifier.wait(self.__state_poll)
 
     async def cleanup(self) -> None:
         await self.__close_device()
@@ -106,7 +123,7 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
         return (self.__active == int(pin))
 
     async def write(self, pin: str, state: bool) -> None:
-        channel = int(pin) + 1
+        channel = int(pin)
         assert 1 <= channel <= 16
         if state:
             await self.__send_command("{:c}{:c}".format(1, channel).encode())
@@ -128,20 +145,36 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
             await self.__close_device()
             raise GpioDriverOfflineError(self)
 
+    async def __ensure_device_tcpip(self) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        try:
+            (reader, writer) = await asyncio.wait_for(
+                asyncio.open_connection(self.__host, self.__port),
+                timeout=self.__timeout,
+            )
+            return (reader, writer)
+        except Exception as err:
+            get_logger(0).error("Can't connect to TESmart KVM [%s]:%d: %s",
+                                self.__host, self.__port, tools.efmt(err))
+            raise GpioDriverOfflineError(self)
+
+    async def __ensure_device_serial(self) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        try:
+            (reader, writer) = await asyncio.wait_for(
+                serial_asyncio.open_serial_connection(url=self.__device_path, baudrate=self.__speed),
+                timeout=self.__timeout,
+            )
+            return (reader, writer)
+        except Exception as err:
+            get_logger(0).error("Can't connect to TESmart KVM [%s]:%d: %s",
+                                self.__device_path, self.__speed, tools.efmt(err))
+            raise GpioDriverOfflineError(self)
+
     async def __ensure_device(self) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
         if self.__reader is None or self.__writer is None:
-            try:
-                (reader, writer) = await asyncio.wait_for(
-                    asyncio.open_connection(self.__host, self.__port),
-                    timeout=self.__timeout,
-                )
-            except Exception as err:
-                get_logger(0).error("Can't connect to TESmart KVM [%s]:%d: %s",
-                                    self.__host, self.__port, tools.efmt(err))
-                raise GpioDriverOfflineError(self)
-            else:
-                self.__reader = reader
-                self.__writer = writer
+            if self.__mode == 1:
+                (self.__reader, self.__writer) = await self.__ensure_devicee_tcpip()
+            elif self.__mode == 2:
+                (self.__reader, self.__writer) = await self.__ensure_device_serial()
         return (self.__reader, self.__writer)
 
     async def __close_device(self) -> None:

--- a/kvmd/plugins/ugpio/tesmart.py
+++ b/kvmd/plugins/ugpio/tesmart.py
@@ -85,7 +85,7 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
 
     @classmethod
     def get_pin_validator(cls) -> Callable[[Any], Any]:
-        return functools.partial(valid_number, min=0, max=15, name="Tesmart channel")
+        return functools.partial(valid_number, min=0, max=15, name="TESmart channel")
 
     async def run(self) -> None:
         prev_active = -2
@@ -123,7 +123,7 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
             await asyncio.wait_for(writer.drain(), timeout=self.__timeout)
             return (await asyncio.wait_for(reader.readexactly(6), timeout=self.__timeout))[4]
         except Exception as err:
-            get_logger(0).error("Can't send command to Tesmart KVM [%s]:%d: %s",
+            get_logger(0).error("Can't send command to TESmart KVM [%s]:%d: %s",
                                 self.__host, self.__port, tools.efmt(err))
             await self.__close_device()
             raise GpioDriverOfflineError(self)
@@ -136,7 +136,7 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
                     timeout=self.__timeout,
                 )
             except Exception as err:
-                get_logger(0).error("Can't connect to Tesmart KVM [%s]:%d: %s",
+                get_logger(0).error("Can't connect to TESmart KVM [%s]:%d: %s",
                                     self.__host, self.__port, tools.efmt(err))
                 raise GpioDriverOfflineError(self)
             else:
@@ -154,6 +154,6 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
     # =====
 
     def __str__(self) -> str:
-        return f"Tesmart({self._instance_name})"
+        return f"TESmart({self._instance_name})"
 
     __repr__ = __str__


### PR DESCRIPTION
Getting started:
- disable Linux serial console and debugging in /boot/cmdline.txt as mentioned in https://docs.pikvm.org/v3/#io-ports-and-jumpers in the orange box under UART
- prepare a console to TESmart cable, it's basically ethernet pins 4,5 from the middle of RJ-45 to the TESmart connector middle, and TXD, RXD lines according to any RJ45 Cisco cable pinout diagram (and the reverse after the first attempt fails)
- https://docs.pikvm.org/tesmart/#adding-ui-elements-to-control-the-kvm-switch - add new parameters to the driver:
```yaml
mode: 2 #RS-232
device: /dev/ttyAMA0
speed: 9600
```

Things to note (or change, feedback appreciated):

1. Changed pin numbers to go from 1 to 16 (for the largest model). The TESmart protocol, both TCP/IP and RS-232, and labels on the device itself, all use 1-based numbering. It really doesn't make sense to move that to 0..15 for PiKVM's config files. But that's just my opinion.

2. As noted in the comment, code requires serial_asyncio module. It's not yet available as an Arch package, so needs to be built from AUR. But you guys already build your own packages so I'm sure this can be handled. With serial_asyncio the only real change is how you open the connection, all read/write calls remained unchanged. This is greate for maintainability. Going the Ezcoo route would require a lot more changes.

3. I didn't find any examples in the other plugins on how to make driver parameters optional, so for now you need to specify both network and serial configuration and switch with a `mode` parameter. Which takes values 1 and 2, because I also couldn't find an example on how to validate a closed list of values like `[ "network", "serial" ]`.
