### PR TITLE
Change name to simplify interface getLedsAs->getLeds.

### DIFF
--- a/hid/lib/drivers/keyboard.h
+++ b/hid/lib/drivers/keyboard.h
@@ -1,0 +1,29 @@
+/*****************************************************************************
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2022  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+*****************************************************************************/
+
+#pragma once
+
+typedef struct
+{
+    bool caps;
+    bool scroll;
+    bool num;
+} KeyboardLedsState;

--- a/hid/src/main.cpp
+++ b/hid/src/main.cpp
@@ -285,11 +285,17 @@ static void _sendResponse(uint8_t code) {
 #		endif
 		if (_usb_kbd) {
 			response[1] |= _usb_kbd->isOffline() ? PROTO::PONG::KEYBOARD_OFFLINE : 0;
-			response[1] |= _usb_kbd->getLedsAs(PROTO::PONG::CAPS, PROTO::PONG::SCROLL, PROTO::PONG::NUM);
+			KeyboardLedsState leds = _usb_kbd->getLeds();
+			response[1] |= leds.caps ? PROTO::PONG::CAPS : 0;
+			response[1] |= leds.num ? PROTO::PONG::NUM : 0;
+			response[1] |= leds.scroll ? PROTO::PONG::SCROLL : 0;
 			response[2] |= PROTO::OUTPUTS1::KEYBOARD::USB;
 		} else if (_ps2_kbd) {
 			response[1] |= _ps2_kbd->isOffline() ? PROTO::PONG::KEYBOARD_OFFLINE : 0;
-			response[1] |= _ps2_kbd->getLedsAs(PROTO::PONG::CAPS, PROTO::PONG::SCROLL, PROTO::PONG::NUM);
+			KeyboardLedsState leds = _usb_kbd->getLeds();
+			response[1] |= leds.caps ? PROTO::PONG::CAPS : 0;
+			response[1] |= leds.num ? PROTO::PONG::NUM : 0;
+			response[1] |= leds.scroll ? PROTO::PONG::SCROLL : 0;
 			response[2] |= PROTO::OUTPUTS1::KEYBOARD::PS2;
 		}
 		if (_usb_mouse_abs) {

--- a/hid/src/ps2/hid.h
+++ b/hid/src/ps2/hid.h
@@ -25,6 +25,7 @@
 #include <Arduino.h>
 #include <ps2dev.h>
 
+#include "keyboard.h"
 #include "keymap.h"
 
 // #define HID_PS2_KBD_CLOCK_PIN	7
@@ -78,13 +79,13 @@ class Ps2Keyboard {
 			return false;
 		}
 
-		uint8_t getLedsAs(uint8_t caps, uint8_t scroll, uint8_t num) {
-			uint8_t result = 0;
+		KeyboardLedsState getLeds() {
+			KeyboardLedsState result;
 
 			periodic();
-			if (_leds & 0b00000100) result |= caps;
-			if (_leds & 0b00000001) result |= scroll;
-			if (_leds & 0b00000010) result |= num;
+			result.caps = _leds & 0b00000100;
+			result.scroll = _leds & 0b00000001;
+			result.num = _leds & 0b00000010;
 			return result;
 		}
 

--- a/hid/src/usb/hid.h
+++ b/hid/src/usb/hid.h
@@ -25,6 +25,7 @@
 #include <Arduino.h>
 #include <HID-Project.h>
 
+#include "keyboard.h"
 #include "../tools.h"
 #ifdef AUM
 #	include "../aum.h"
@@ -104,12 +105,12 @@ class UsbKeyboard {
 
 		CLS_IS_OFFLINE(_kbd)
 
-		uint8_t getLedsAs(uint8_t caps, uint8_t scroll, uint8_t num) {
+		KeyboardLedsState getLeds() {
 			uint8_t leds = _kbd.getLeds();
-			uint8_t result = 0;
-			if (leds & LED_CAPS_LOCK) result |= caps;
-			if (leds & LED_SCROLL_LOCK) result |= scroll;
-			if (leds & LED_NUM_LOCK) result |= num;
+			KeyboardLedsState result;
+			result.caps =  leds & LED_CAPS_LOCK;
+			result.scroll = leds & LED_SCROLL_LOCK;
+			result.num = leds & LED_NUM_LOCK;
 			return result;
 		}
 


### PR DESCRIPTION
It break abstraction between driver and protocol.
The driver type (win98 fix) is part of protocol anyway so I decided to do it that way.
Driver dependent part of PROTO could be put in separate file.
It would make PROTO less clean so I don't want to do that.

Part of https://github.com/pikvm/kvmd/pull/90