### PR TITLE
Allow to run with unpatched kernel

### DIFF
--- a/kvmd/apps/otg/__init__.py
+++ b/kvmd/apps/otg/__init__.py
@@ -50,8 +50,12 @@ def _mkdir(path: str) -> None:
     os.mkdir(path)
 
 
-def _chown(path: str, user: str) -> None:
-    get_logger().info("CHOWN --- %s - %s", user, path)
+def _chown(path: str, user: str, optional: bool=False) -> None:
+    logger = get_logger()
+    if optional and not os.access(path, os.F_OK):
+        logger.info("CHOWN --- %s - [SKIPPED] %s", user, path)
+        return
+    logger.info("CHOWN --- %s - %s", user, path)
     shutil.chown(path, user)
 
 
@@ -182,7 +186,7 @@ class _GadgetConfig:
             _chown(join(func_path, "lun.0/cdrom"), user)
             _chown(join(func_path, "lun.0/ro"), user)
             _chown(join(func_path, "lun.0/file"), user)
-            _chown(join(func_path, "lun.0/forced_eject"), user)
+            _chown(join(func_path, "lun.0/forced_eject"), user, optional=True)
         _symlink(func_path, join(self.__profile_path, func))
         name = ("Mass Storage Drive" if self.__msd_instance == 0 else f"Extra Drive #{self.__msd_instance}")
         self.__create_meta(func, name)

--- a/kvmd/apps/otgmsd/__init__.py
+++ b/kvmd/apps/otgmsd/__init__.py
@@ -38,6 +38,10 @@ def _get_param_path(gadget: str, instance: int, param: str) -> str:
     return usb.get_gadget_path(gadget, usb.G_FUNCTIONS, f"mass_storage.usb{instance}/lun.0", param)
 
 
+def _has_param(gadget: str, instance: int, param: str) -> bool:
+    return os.access(_get_param_path(gadget, instance, param), os.F_OK)
+
+
 def _get_param(gadget: str, instance: int, param: str) -> str:
     with open(_get_param_path(gadget, instance, param)) as param_file:
         return param_file.read().strip()
@@ -84,11 +88,15 @@ def main(argv: (list[str] | None)=None) -> None:
         raise SystemExit(f"Error: KVMD MSD not using 'otg'"
                          f" (now configured {config.kvmd.msd.type!r})")
 
+    has_param = (lambda param: _has_param(config.otg.gadget, options.instance, param))
     set_param = (lambda param, value: _set_param(config.otg.gadget, options.instance, param, value))
     get_param = (lambda param: _get_param(config.otg.gadget, options.instance, param))
 
     if options.eject:
-        set_param("forced_eject", "")
+        if has_param("forced_eject"):
+            set_param("forced_eject", "")
+        else:
+            set_param("file", "")
 
     if options.set_cdrom is not None:
         set_param("cdrom", str(int(options.set_cdrom)))

--- a/kvmd/plugins/msd/otg/drive.py
+++ b/kvmd/plugins/msd/otg/drive.py
@@ -51,7 +51,7 @@ class Drive:
     # =====
 
     def set_image_path(self, path: str) -> None:
-        if path:
+        if path or not self.__has_param("forced_eject"):
             self.__set_param("file", path)
         else:
             self.__set_param("forced_eject", "")
@@ -72,6 +72,9 @@ class Drive:
         return (not int(self.__get_param("ro")))
 
     # =====
+
+    def __has_param(self, param: str) -> bool:
+        return os.access(os.path.join(self.__lun_path, param), os.F_OK)
 
     def __get_param(self, param: str) -> str:
         with open(os.path.join(self.__lun_path, param)) as param_file:


### PR DESCRIPTION
These day, I'm trying to port pikvm to other devices. I notice that it can run well with unpatched kernel. So I think we can keep this compatibility.