### PR TITLE
Use `dbus` instand of `dbus-next`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -51,7 +51,6 @@ depends=(
 	python-netifaces
 	python-systemd
 	python-dbus
-	python-dbus-next
 	python-pygments
 	python-pyghmi
 	python-pam

--- a/kvmd/apps/kvmd/sysunit.py
+++ b/kvmd/apps/kvmd/sysunit.py
@@ -22,38 +22,33 @@
 
 import types
 
-import dbus_next
-import dbus_next.aio
-import dbus_next.aio.proxy_object
-import dbus_next.introspection
-import dbus_next.errors
+import dbus
+import dbus.exceptions
 
 
 # =====
 class SystemdUnitInfo:
     def __init__(self) -> None:
-        self.__bus: (dbus_next.aio.MessageBus | None) = None
-        self.__intr: (dbus_next.introspection.Node | None) = None
-        self.__manager: (dbus_next.aio.proxy_object.ProxyInterface | None) = None
+        self.__bus: (dbus.SystemBus | None) = None
+        self.__manager: (dbus.Interface | None) = None
 
     async def get_status(self, name: str) -> tuple[bool, bool]:
         assert self.__bus is not None
-        assert self.__intr is not None
         assert self.__manager is not None
 
         if not name.endswith(".service"):
             name += ".service"
 
         try:
-            unit_p = await self.__manager.call_get_unit(name)  # type: ignore
-            unit = self.__bus.get_proxy_object("org.freedesktop.systemd1", unit_p, self.__intr)
-            unit_props = unit.get_interface("org.freedesktop.DBus.Properties")
-            started = ((await unit_props.call_get("org.freedesktop.systemd1.Unit", "ActiveState")).value == "active")  # type: ignore
-        except dbus_next.errors.DBusError as err:
-            if err.type != "org.freedesktop.systemd1.NoSuchUnit":
+            unit_p = self.__manager.GetUnit(name)
+            unit = self.__bus.get_object("org.freedesktop.systemd1", unit_p)
+            unit_props = dbus.Interface(unit, dbus_interface="org.freedesktop.DBus.Properties")
+            started = (unit_props.Get("org.freedesktop.systemd1.Unit", "ActiveState") == "active")
+        except dbus.exceptions.DBusException as err:
+            if "NoSuchUnit" not in str(err):
                 raise
             started = False
-        enabled = ((await self.__manager.call_get_unit_file_state(name)) in [  # type: ignore
+        enabled = (self.__manager.GetUnitFileState(name) in [
             "enabled",
             "enabled-runtime",
             "static",
@@ -63,10 +58,9 @@ class SystemdUnitInfo:
         return (enabled, started)
 
     async def open(self) -> None:
-        self.__bus = await dbus_next.aio.MessageBus(bus_type=dbus_next.BusType.SYSTEM).connect()
-        self.__intr = await self.__bus.introspect("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
-        systemd = self.__bus.get_proxy_object("org.freedesktop.systemd1", "/org/freedesktop/systemd1", self.__intr)
-        self.__manager = systemd.get_interface("org.freedesktop.systemd1.Manager")
+        self.__bus = dbus.SystemBus()
+        systemd = self.__bus.get_object("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
+        self.__manager = dbus.Interface(systemd, dbus_interface="org.freedesktop.systemd1.Manager")
 
     async def __aenter__(self) -> "SystemdUnitInfo":
         await self.open()
@@ -75,12 +69,10 @@ class SystemdUnitInfo:
     async def close(self) -> None:
         try:
             if self.__bus is not None:
-                self.__bus.disconnect()
-                await self.__bus.wait_for_disconnect()
+                self.__bus.close()
         except Exception:
             pass
         self.__manager = None
-        self.__intr = None
         self.__bus = None
 
     async def __aexit__(

--- a/testenv/Dockerfile
+++ b/testenv/Dockerfile
@@ -46,7 +46,6 @@ RUN pacman --noconfirm --ask=4 -Syy \
 		python-netifaces \
 		python-systemd \
 		python-dbus \
-		python-dbus-next \
 		python-pygments \
 		python-pam \
 		python-pillow \


### PR DESCRIPTION
These day, I'm trying to package `kvmd` as debian package. So we can support more devices easily with [`Armbian`](https://github.com/armbian/build). But unfortunately, Debian don't have package - `python3-dbus-next`.

I'm not sure whether you like this change. Or only apply this patch durning build debian package?