### PR TITLE
nginx: serve ACME challenges over unencrypted HTTP

### DIFF
--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -39,6 +39,7 @@ http {
 	server {
 		server_name localhost;
 		include /etc/kvmd/nginx/listen-http.conf;
+		include /etc/kvmd/nginx/certbot.ctx-server.conf;
 		include /etc/kvmd/nginx/redirect-to-https.conf;
 	}
 
@@ -47,7 +48,6 @@ http {
 		include /etc/kvmd/nginx/listen-https.conf;
 		include /etc/kvmd/nginx/ssl.conf;
 		include /etc/kvmd/nginx/kvmd.ctx-server.conf;
-		include /etc/kvmd/nginx/certbot.ctx-server.conf;
 		include /usr/share/kvmd/extras/*/nginx.ctx-server.conf;
 	}
 }

--- a/configs/nginx/redirect-to-https.conf
+++ b/configs/nginx/redirect-to-https.conf
@@ -1,1 +1,3 @@
-return 301 https://$host$request_uri;
+location / {
+	return 301 https://$host$request_uri;
+}


### PR DESCRIPTION
This PR makes nginx serve ACME challenges from port 80, without redirecting to HTTPS. Redirect to HTTPS is pointless (HTTPS doesn't add anything).

It also prevents obtaining keys for machines without public IP, but connected over wireguard (or other VPN) to a machine with public IP, and with public DNS pointing to the public proxy, not to the real pikvm in the intranet. For me this is a preferred mechanism since it avoids disseminating DNS keys to all machines.