### PR TITLE
Add gzip support to nginx.conf

### DIFF
--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -27,6 +27,10 @@ http {
 	keepalive_timeout 10;
 	client_max_body_size 4k;
 
+	gzip                    on;
+	gzip_proxied            any;
+	gzip_types              text/plain text/css application/json text/javascript;
+
 	client_body_temp_path	/tmp/kvmd-nginx/client_body_temp;
 	fastcgi_temp_path		/tmp/kvmd-nginx/fastcgi_temp;
 	proxy_temp_path			/tmp/kvmd-nginx/proxy_temp;


### PR DESCRIPTION
When the Web UI is used over constrained connections, gzip compression might help make it snappier. At the default compression level it consumes a negligible amount of CPU resources.