### PR TITLE
Fix YAML Loader to handle lists

### DIFF
--- a/kvmd/tools.py
+++ b/kvmd/tools.py
@@ -51,6 +51,9 @@ def merge(dest: dict, src: dict) -> None:
             if isinstance(dest[key], dict) and isinstance(src[key], dict):
                 merge(dest[key], src[key])
                 continue
+            if isinstance(dest[key], list) and isinstance(src[key], list):
+                dest[key].extend(src[key])
+                continue
         dest[key] = src[key]
 
 


### PR DESCRIPTION
When adding discrete items to `/etc/kvmd/override.d`, the `view: table:` is loaded as a list.  Currently PiKVM overwrites this list with the new list every time because there is no handler for lists.  This adds a handler, allowing individual override.d files using lists to provide discrete functionality without interfering with other override.d items.

An example.  These two items are loaded from individual files within `/etc/kvmd/override.d` using this change.  Previously, only the Download Certificate (marked in red) would be loaded.  Now both the Mouse Jiggler and the Download Certificate link are loaded.   
![image](https://user-images.githubusercontent.com/527919/227267929-6c02f7c4-fa59-4fbd-9ddb-4446f7dff1cc.png)
