### PR TITLE
Correct copy behavior during temporary directory set up

### DIFF
--- a/scripts/kvmd-certbot
+++ b/scripts/kvmd-certbot
@@ -108,7 +108,7 @@ case "$1" in
 	renew)
 		shift
 		create_tmp
-		cp -a "$cur"/{config,work,logs} "$tmp"
+		cp -a "$cur"/* "$tmp"
 		chown -R "$user:" "$tmp"
 		sed -s -i -e "s| = $cur/| = $tmp/|g" "$tmp/config/renewal/"*
 		sudo --preserve-env -u "$user" certbot renew "$@" \


### PR DESCRIPTION
Corrects a bug in which authentication files stored in the `/runroot` directory, rather than subdirectories, would be missed while the script sets up the temporary working directory for certificate renewals. This leads to a failure of the rest of the renewal procedure in kvmd-certbot due to it being unable to find the authentication file after switching to the temporary working directory. This patch changes the copy behavior to copy all files and subdirectories rather than just the 3 subfolders of `/runroot`.