### PR TITLE
Introducing a dictionary view and a new merge mode for GPIO UI elements

### DIFF
--- a/kvmd/apps/__init__.py
+++ b/kvmd/apps/__init__.py
@@ -492,6 +492,7 @@ def _get_config_scheme() -> dict:
                         "title": Option("GPIO", type=valid_ugpio_view_title),
                     },
                     "table": Option([], type=valid_ugpio_view_table),
+                    "dict": Option({}, type=dict)
                 },
             },
         },

--- a/kvmd/apps/kvmd/ugpio.py
+++ b/kvmd/apps/kvmd/ugpio.py
@@ -252,9 +252,9 @@ class UserGpio:
                 self.__inputs[channel] = _GpioInput(channel, ch_config, driver)
             else:  # output:
                 self.__outputs[channel] = _GpioOutput(channel, ch_config, driver, self.__notifier)
-        viewTable=self.__view["table"]
-        viewMap = self.__view["dict"]
-        viewTable.extend(list(viewMap.values()))
+
+        self.__view["table"].extend(list(self.__view["dict"].values()))
+
     async def get_model(self) -> dict:
         return {
             "scheme": {
@@ -335,8 +335,7 @@ class UserGpio:
 
     def __make_view_table(self) -> list[list[dict] | None]:
         table: list[list[dict] | None] = []
-        viewTable = self.__view["table"]
-        for row in viewTable:
+        for row in self.__view["table"]:
             if len(row) == 0:
                 table.append(None)
                 continue

--- a/kvmd/apps/kvmd/ugpio.py
+++ b/kvmd/apps/kvmd/ugpio.py
@@ -252,7 +252,9 @@ class UserGpio:
                 self.__inputs[channel] = _GpioInput(channel, ch_config, driver)
             else:  # output:
                 self.__outputs[channel] = _GpioOutput(channel, ch_config, driver, self.__notifier)
-
+        viewTable=self.__view["table"]
+        viewMap = self.__view["dict"]
+        viewTable.extend(list(viewMap.values()))
     async def get_model(self) -> dict:
         return {
             "scheme": {
@@ -334,8 +336,6 @@ class UserGpio:
     def __make_view_table(self) -> list[list[dict] | None]:
         table: list[list[dict] | None] = []
         viewTable = self.__view["table"]
-        viewMap = self.__view["dict"]
-        viewTable.extend(list(viewMap.values()))
         for row in viewTable:
             if len(row) == 0:
                 table.append(None)

--- a/kvmd/apps/kvmd/ugpio.py
+++ b/kvmd/apps/kvmd/ugpio.py
@@ -333,7 +333,10 @@ class UserGpio:
 
     def __make_view_table(self) -> list[list[dict] | None]:
         table: list[list[dict] | None] = []
-        for row in self.__view["table"]:
+        viewTable = self.__view["table"]
+        viewMap = self.__view["dict"]
+        viewTable.extend(list(viewMap.values()))
+        for row in viewTable:
             if len(row) == 0:
                 table.append(None)
                 continue

--- a/kvmd/validators/ugpio.py
+++ b/kvmd/validators/ugpio.py
@@ -52,6 +52,8 @@ def valid_ugpio_view_title(arg: Any) -> (str | list[str]):
 
 def valid_ugpio_view_table(arg: Any) -> list[list[str]]:  # pylint: disable=inconsistent-return-statements
     try:
+        if isinstance(arg, dict):
+            arg = arg.values()
         return [list(map(str, row)) for row in list(arg)]
     except Exception:
         raise_error("<skipped>", "GPIO view table")


### PR DESCRIPTION
This commit introduces a "simpler" validator solution that allows for either lists operating in replace/clobber mode or dicts that will be clobbered if a list is defined later during initialization. Additionally, it adds a new "kvmd: gpio: view: dict:" key that operates in merge mode, maintaining backward compatibility with "kvmd: gpio: view: table:" while allowing multiple files to merge list items within the override.d/ to define UI elements within GPIO.

For more information on the changes made, please see our discussion on Discord: https://discord.com/channels/580094191938437144/880066200959328328/1092455765211619428.
