### PR TITLE
Set focus on text area when text is clicked.

### DIFF
--- a/web/share/js/kvm/main.js
+++ b/web/share/js/kvm/main.js
@@ -47,7 +47,7 @@ export function main() {
 		initWindowManager();
 
 		tools.el.setOnClick($("open-log-button"), () => window.open("/api/log?seek=3600&follow=1", "_blank"));
-		tools.el.setOnClick($("text-dropdown"), () => $("hid-pak-text").focus());
+		new MutationObserver(() => $("text-menu").style.visibility != "hidden" && $("hid-pak-text").focus()).observe($("text-menu"), {"attributes": true});
 		
 		if (tools.config.getBool("kvm--full-tab-stream", false)) {
 			wm.toggleFullTabWindow($("stream-window"), true);

--- a/web/share/js/kvm/main.js
+++ b/web/share/js/kvm/main.js
@@ -47,7 +47,8 @@ export function main() {
 		initWindowManager();
 
 		tools.el.setOnClick($("open-log-button"), () => window.open("/api/log?seek=3600&follow=1", "_blank"));
-
+		tools.el.setOnClick($("text-dropdown"), () => $("hid-pak-text").focus());
+		
 		if (tools.config.getBool("kvm--full-tab-stream", false)) {
 			wm.toggleFullTabWindow($("stream-window"), true);
 		}


### PR DESCRIPTION
This patch removes one of the 4-steps required in order to copy and paste into PiKVM.   When the Text menu is clicked, the focus is set on the Text Area.