### PR TITLE
sysctl: tune dirty data writeback policies

### DIFF
--- a/configs/os/sysctl.conf
+++ b/configs/os/sysctl.conf
@@ -1,6 +1,7 @@
-# https://github.com/raspberrypi/linux/issues/1753
-vm.dirty_background_bytes = 5
-vm.dirty_writeback_centisecs = 25
+# Overly-aggressive data writeback policies to minimize the chance of data corruption
+# Start dirty data writeback when it exceeds 256 KiB or 1s has passed
+vm.dirty_background_bytes = 262144
+vm.dirty_writeback_centisecs = 100
 
 # https://groups.google.com/g/meetecho-janus/c/xoWIQfaoJm8
 net.core.rmem_default = 500000


### PR DESCRIPTION
The existing policy sets dirty_background_bytes to 5, which is erroneously too small that incurs write amplification and read starvations. Considering a raspi with 2 GiB of RAM, this is 43 million times smaller than the default Linux policy, which is 10%.

Considering that this will be deployed to mostly read-only system with emphasis on data integrity (hence needing tighter data writeback), set this to 256 KiB.

Continuing addressing the overly excessive data writeback policies, also bump the dirty_writeback_centisecs from 250ms to 1000ms. Any dirty data written in the past 1 second will be written to the storage.