### PR TITLE
Fix crash on unload

### DIFF
--- a/web/share/js/kvm/main.js
+++ b/web/share/js/kvm/main.js
@@ -36,7 +36,9 @@ export function main() {
 			if (value) {
 				window.onbeforeunload = function(event) {
 					let text = "Are you sure you want to close PiKVM session?";
-					event.returnValue = text;
+					if (event){
+						event.returnValue = text;
+					}
 					return text;
 				};
 			} else {

--- a/web/share/js/kvm/main.js
+++ b/web/share/js/kvm/main.js
@@ -36,7 +36,7 @@ export function main() {
 			if (value) {
 				window.onbeforeunload = function(event) {
 					let text = "Are you sure you want to close PiKVM session?";
-					if (event){
+					if (event) {
 						event.returnValue = text;
 					}
 					return text;


### PR DESCRIPTION
Within main, exists a `window.beforeunload` handler which brings up the "Are you sure you want to close PiKVM session?" message.   When the page is refreshed, the event is `undefined` and, the code which sets the `event.returnValue` to the aforementioned text provides an exception.  

To reproduce:
1. Open KVMD web
2. Open developer tools to view Console.
3. Interact with the page by clicking the main window.
4. Refresh the page
5. Observe type error in console. 

This patch checks if the event is defined before attempting to set the `event.returnValue`.  Other functions are maintained.