### PR TITLE
Turn off auto capitalize on the username input field

### DIFF
--- a/web/login/index.html
+++ b/web/login/index.html
@@ -51,7 +51,7 @@
             <tr>
               <td>Username:&nbsp;</td>
               <td>
-                <input type="text" id="user-input">
+                <input type="text" id="user-input" autocapitalize="off">
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Fixes user login on iDevices by disabling capitalization on the username input field on the login homepage. 