### PR TITLE
web/kvm: Replace U+1F5AA with U+1F4BE

### DIFF
--- a/web/kvm/index.html
+++ b/web/kvm/index.html
@@ -500,7 +500,7 @@
                 <select disabled id="msd-image-selector"></select>
               </td>
               <td>
-                <button disabled id="msd-download-button" title="Download image">&nbsp;&nbsp;&#128426;&nbsp;&nbsp;</button>
+                <button disabled id="msd-download-button" title="Download image">&nbsp;&nbsp;&#128190;&nbsp;&nbsp;</button>
               </td>
               <td>
                 <button disabled id="msd-remove-button" title="Remove image"><b>&nbsp;&nbsp;&times;&nbsp;&nbsp;</b></button>

--- a/web/kvm/navbar-msd.pug
+++ b/web/kvm/navbar-msd.pug
@@ -4,7 +4,7 @@ li(id="msd-dropdown" class="right feature-disabled")
 		span Drive
 	div(id="msd-menu" class="menu")
 		div(class="text")
-			b Mass Storage Drive: 
+			b Mass Storage Drive:
 			span(id="msd-status")
 			br
 		hr
@@ -37,7 +37,7 @@ li(id="msd-dropdown" class="right feature-disabled")
 			tr
 				td Image:
 				td(width="100%") #[select(disabled id="msd-image-selector")]
-				td #[button(disabled id="msd-download-button" title="Download image") &nbsp;&nbsp;&#128426;&nbsp;&nbsp;]
+				td #[button(disabled id="msd-download-button" title="Download image") &nbsp;&nbsp;&#128190;&nbsp;&nbsp;]
 				td #[button(disabled id="msd-remove-button" title="Remove image") #[b &nbsp;&nbsp;&times;&nbsp;&nbsp;]]
 		table(class="kv")
 			tr


### PR DESCRIPTION
https://emojipedia.org/black-hard-shell-floppy-disk doesn't work on macOS/iOS

https://emojipedia.org/floppy-disk does

https://codepoints.net/U+1F5AA?lang=en
https://codepoints.net/U+1F4BE?lang=en

Fixes https://github.com/pikvm/pikvm/issues/1095