### PR TITLE
[v2-hdmi-rpi3.yaml] add h264 sink from v1

### DIFF
--- a/configs/kvmd/main/v2-hdmi-rpi3.yaml
+++ b/configs/kvmd/main/v2-hdmi-rpi3.yaml
@@ -40,9 +40,15 @@ kvmd:
             - "--no-log-colors"
             - "--sink=kvmd::ustreamer::jpeg"
             - "--sink-mode=0660"
+            - "--h264-sink=kvmd::ustreamer::h264"
+            - "--h264-sink-mode=0660"
+            - "--h264-bitrate={h264_bitrate}"
+            - "--h264-gop={h264_gop}"
 
 
 vnc:
     memsink:
         jpeg:
             sink: "kvmd::ustreamer::jpeg"
+        h264:
+            sink: "kvmd::ustreamer::h264"


### PR DESCRIPTION
Seems that v2-hdmi-rpi3 lost h264 support from v1 somehow.

Tested h264 support on v2 with rpi3a+