### PR TITLE
kvmd-udev-hdmiusb-check: Add support for rPi4 b rev 1.5

### DIFF
--- a/scripts/kvmd-udev-hdmiusb-check
+++ b/scripts/kvmd-udev-hdmiusb-check
@@ -48,7 +48,7 @@ case "$board" in
 		esac;;
 	"rpi4")
 		case "$model" in
-			"Raspberry Pi 4 Model B Rev 1.1" | "Raspberry Pi 4 Model B Rev 1.2" | "Raspberry Pi 4 Model B Rev 1.4")
+			"Raspberry Pi 4 Model B Rev 1.1" | "Raspberry Pi 4 Model B Rev 1.2" | "Raspberry Pi 4 Model B Rev 1.4" | "Raspberry Pi 4 Model B Rev 1.5")
 				if [ "$port" == "1-1.4:1.0" ]; then exit 0; else exit 1; fi;;
 			*) exit 0;;
 		esac;;


### PR DESCRIPTION
Adds support for the following new revision of the board:

```bash
# tr < /proc/device-tree/model -d '\000'
Raspberry Pi 4 Model B Rev 1.5
```

Without this, `/dev/video19` from the `rpivid_hevc` driver gets incorrectly linked to `/dev/kvmd-video`

```bash
[root@pikvm ~]# v4l2-ctl --list-dev
rpivid (platform:rpivid):
	/dev/video19
	/dev/media0
```

```bash
lrwxrwxrwx 1 root root 6 Sep 28 08:14 /dev/kvmd-video -> video19
```