### PR TITLE
Update kvmd-udev-hdmiusb-check

### DIFF
--- a/scripts/kvmd-udev-hdmiusb-check
+++ b/scripts/kvmd-udev-hdmiusb-check
@@ -49,7 +49,7 @@ case "$board" in
 	"rpi4")
 		case "$model" in
 			"Raspberry Pi 4 Model B Rev 1.1" | "Raspberry Pi 4 Model B Rev 1.2" | "Raspberry Pi 4 Model B Rev 1.4" | "Raspberry Pi 4 Model B Rev 1.5")
-				if [ "$port" == "1-1.4:1.0" ]; then exit 0; else exit 1; fi;;
+				if [ "$port" == "1-1.4:1.0" ] || [ "$port" == "2-1:1.0" ]; then exit 0; else exit 1; fi;;
 			*) exit 0;;
 		esac;;
 	*) exit 1;;


### PR DESCRIPTION
This is to allow USB 3.0 Capture Cards to be used in the top USB port, this is to allow Macrosilicon's MS2130 to be used with PiKVM, when doing this it must also be switched to pixel format yuyv in the override.yaml