### PR TITLE
Keyboard Issues #19 fix (https://github.com/No0ne/ps2x2pico/issues/19)

### DIFF
--- a/hid/pico/CMakeLists.txt
+++ b/hid/pico/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 
 set(PICO_SDK_PATH ${CMAKE_CURRENT_LIST_DIR}/.pico-sdk)
 set(PICO_TINYUSB_PATH ${CMAKE_CURRENT_LIST_DIR}/.tinyusb)
-set(PS2_PATH ${CMAKE_CURRENT_LIST_DIR}/.ps2x2pico)
+set(PS2_PATH ${CMAKE_CURRENT_LIST_DIR}/.ps2x2pico/src)
 
 # For TinyUSB
 set(FAMILY rp2040)

--- a/hid/pico/Makefile
+++ b/hid/pico/Makefile
@@ -31,7 +31,7 @@ endef
 .tinyusb:
 	$(call libdep,tinyusb,hathach/tinyusb,d713571cd44f05d2fc72efc09c670787b74106e0)
 .ps2x2pico:
-	$(call libdep,ps2x2pico,No0ne/ps2x2pico,d95332b4ea11cad4a11da070857e613c80f9b935)
+	$(call libdep,ps2x2pico,No0ne/ps2x2pico,b90814df40ebbc0f42c2886b4bd17b20a177a4da)
 deps: .pico-sdk .tinyusb .ps2x2pico
 
 


### PR DESCRIPTION
This fixes two bugs regarding ghost mouse movement and key presses mentioned here: https://github.com/No0ne/ps2x2pico/issues/19

The default 10ms polling rate could be a bit too much for some systems.
Thats why I still need to implement the mouse decoupling mentioned here: https://github.com/No0ne/ps2x2pico/issues/1#issuecomment-1849435280