### PR TITLE
ps2: keyboard passthru support

### DIFF
--- a/hid/pico/Makefile
+++ b/hid/pico/Makefile
@@ -31,7 +31,7 @@ endef
 .tinyusb:
 	$(call libdep,tinyusb,hathach/tinyusb,d713571cd44f05d2fc72efc09c670787b74106e0)
 .ps2x2pico:
-	$(call libdep,ps2x2pico,No0ne/ps2x2pico,b90814df40ebbc0f42c2886b4bd17b20a177a4da)
+	$(call libdep,ps2x2pico,No0ne/ps2x2pico,a103d33fbfe29b510175ceba3079057de0dcd09d)
 deps: .pico-sdk .tinyusb .ps2x2pico
 
 

--- a/hid/pico/src/CMakeLists.txt
+++ b/hid/pico/src/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(${target_name} PRIVATE
 	ph_debug.c
 
 	${PS2_PATH}/ps2phy.c
+	${PS2_PATH}/ps2pt.c
 	${PS2_PATH}/ps2kb.c
 	${PS2_PATH}/ps2ms.c
 )
@@ -24,6 +25,7 @@ target_compile_options(${target_name} PRIVATE -Wall -Wextra)
 target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${PS2_PATH})
 
 pico_generate_pio_header(${target_name} ${PS2_PATH}/ps2phy.pio)
+pico_generate_pio_header(${target_name} ${PS2_PATH}/ps2pt.pio)
 
 target_link_libraries(${target_name} PRIVATE
 	pico_stdlib

--- a/hid/pico/src/ph_ps2.c
+++ b/hid/pico/src/ph_ps2.c
@@ -31,7 +31,8 @@
 #define _LS_POWER_PIN	13
 #define _KBD_DATA_PIN	11 // CLK == 12
 #define _MOUSE_DATA_PIN	14 // CLK == 15
-
+#define _KBD_PT_DATA_PIN	26 // passthru, CLK == 27
+#define _MOUSE_PT_DATA_PIN	16 // passthru, CLK == 17
 
 u8 ph_g_ps2_kbd_leds = 0;
 bool ph_g_ps2_kbd_online = 0;
@@ -57,15 +58,17 @@ void ph_ps2_init(void) {
 	}
 
 	if (PH_O_IS_KBD_PS2) {
-		kb_init(_KBD_DATA_PIN);
+		kb_init(_KBD_DATA_PIN, _KBD_PT_DATA_PIN);
 	} else {
 		INIT_STUB(_KBD_DATA_PIN);
+		INIT_STUB(_KBD_PT_DATA_PIN);
 	}
 
 	if (PH_O_IS_MOUSE_PS2) {
-		ms_init(_MOUSE_DATA_PIN);
+		ms_init(_MOUSE_DATA_PIN, _MOUSE_PT_DATA_PIN);
 	} else {
 		INIT_STUB(_MOUSE_DATA_PIN);
+		INIT_STUB(_MOUSE_PT_DATA_PIN);
 	}
 
 #	undef INIT_STUB
@@ -123,13 +126,13 @@ void ph_ps2_mouse_send_wheel(s8 h, s8 v) {
 
 void ph_ps2_send_clear(void) {
 	if (PH_O_IS_KBD_PS2) {
-		for(u8 key = 0xe0; key <= 0xe7; key++) {
-			kb_send_key(key, false, 0);
-		}
+		//for(u8 key = 0xe0; key <= 0xe7; key++) {
+		//	kb_send_key(key, false, 0);
+		//}
 
-		for(u8 key = 4; key <= 116; key++) {
-			kb_send_key(key, false, 0);
-		}
+		//for(u8 key = 4; key <= 115; key++) {
+		//kb_send_key(key, false, 0);
+		//}
 	}
 
 	if (PH_O_IS_MOUSE_PS2) {

--- a/hid/pico/src/ph_ps2.h
+++ b/hid/pico/src/ph_ps2.h
@@ -34,12 +34,12 @@ void ph_ps2_init(void);
 void ph_ps2_task(void);
 
 void tuh_kb_set_leds(u8 leds);
-void kb_init(u8 gpio);
+void kb_init(u8 gpio, u8 passthru);
 bool kb_task();
 void kb_send_key(u8 key, bool state, u8 modifiers);
 void ph_ps2_kbd_send_key(u8 key, bool state);
 
-void ms_init(u8 gpio);
+void ms_init(u8 gpio, u8 passthru);
 bool ms_task();
 void ms_send_packet(u8 buttons, s8 x, s8 y, s8 h, s8 v);
 void ph_ps2_mouse_send_button(u8 button, bool state);


### PR DESCRIPTION
I'm currently implementing this: https://github.com/pikvm/pikvm/issues/476

At the moment only keyboard passthru works.
The GPIOs used are 26=data and 27=clock.

@mdevaev please try it out, if you are happy I'll continue with mouse support.