### PR TITLE
bump to ps2x2pico-1.1

### DIFF
--- a/hid/pico/Makefile
+++ b/hid/pico/Makefile
@@ -31,7 +31,7 @@ endef
 .tinyusb:
 	$(call libdep,tinyusb,hathach/tinyusb,d713571cd44f05d2fc72efc09c670787b74106e0)
 .ps2x2pico:
-	$(call libdep,ps2x2pico,No0ne/ps2x2pico,b28bef9743632a56db48f14175aacf7bb23dbd07)
+	$(call libdep,ps2x2pico,No0ne/ps2x2pico,823260af57dcc55cf7cb96241346f51c065126de)
 deps: .pico-sdk .tinyusb .ps2x2pico
 
 

--- a/hid/pico/src/CMakeLists.txt
+++ b/hid/pico/src/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(${target_name} PRIVATE
 	${PS2_PATH}/ps2phy.c
 	${PS2_PATH}/ps2kb.c
 	${PS2_PATH}/ps2ms.c
+	${PS2_PATH}/scancodesets.c
 )
 target_link_options(${target_name} PRIVATE -Xlinker --print-memory-usage)
 target_compile_options(${target_name} PRIVATE -Wall -Wextra)


### PR DESCRIPTION
Please also merge this to the master branch.
It contains multiple bugfixes and scancode set 3 support for e.g. Silicon Graphics workstations.
Afterwards I'll continue with PS/2 passthru support.