### PR TITLE
Update Gencert with TLS1.3 compatibility

### DIFF
--- a/scripts/kvmd-gencert
+++ b/scripts/kvmd-gencert
@@ -20,69 +20,6 @@
 #                                                                            #
 # ========================================================================== #
 
-
-set -e
-export LC_ALL=C
-
-if [ "$(whoami)" != root ]; then
-	echo "Only root can do that"
-	exit 1
-fi
-
-if [ "$1" != --do-the-thing ]; then
-	echo "This script will generate new self-signed SSL certificates for KVMD Nginx"
-	echo "and put them to /etc/kvmd/nginx/ssl. If you're sure of what you're doing,"
-	echo "append the option '--do-the-thing' to execute. You can also append --vnc"
-	echo "to generate a certificate for VNC not for Nginx."
-	exit 1
-fi
-
-target=nginx
-if [ "$2" == --vnc ]; then
-	target=vnc
-fi
-path="/etc/kvmd/$target/ssl"
-
-set -x
-
-mkdir -p "$path"
-rm -f "$path"/*
-cd "$path"
-
-# XXX: Why ECC?
-#   - https://www.leaderssl.com/articles/345-what-is-ecc-and-why-you-should-use-it
-#   - https://www.digitalocean.com/community/tutorials/how-to-create-an-ecc-certificate-on-nginx-for-debian-8
-#   - https://msol.io/blog/tech/create-a-self-signed-ecc-certificate
-openssl ecparam -out server.key -name prime256v1 -genkey
-openssl req -new -x509 -sha256 -nodes -key server.key -out server.crt -days 3650 \
-	-subj "/C=RU/ST=Moscow/L=Moscow/O=PiKVM/OU=PiKVM/CN=localhost"
-
-chown "root:kvmd-$target" "$path"/*
-chmod 440 "$path/server.key"
-chmod 444 "$path/server.crt"
-chmod 755 "$path"
-#!/bin/bash
-# ========================================================================== #
-#                                                                            #
-#    KVMD - The main PiKVM daemon.                                           #
-#                                                                            #
-#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
-#                                                                            #
-#    This program is free software: you can redistribute it and/or modify    #
-#    it under the terms of the GNU General Public License as published by    #
-#    the Free Software Foundation, either version 3 of the License, or       #
-#    (at your option) any later version.                                     #
-#                                                                            #
-#    This program is distributed in the hope that it will be useful,         #
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
-#    GNU General Public License for more details.                            #
-#                                                                            #
-#    You should have received a copy of the GNU General Public License       #
-#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
-#                                                                            #
-# ========================================================================== #
-
 set -e
 export LC_ALL=C
 
@@ -114,7 +51,7 @@ else
 	serial="0000000000000000"
 fi
 
-san="DNS:pikvm-${serialnumber}.local"
+san="DNS:pikvm-${serial}.local"
 
 # Function to fetch IP addresses
 get_ip_addresses() {

--- a/scripts/kvmd-gencert
+++ b/scripts/kvmd-gencert
@@ -61,3 +61,108 @@ chown "root:kvmd-$target" "$path"/*
 chmod 440 "$path/server.key"
 chmod 444 "$path/server.crt"
 chmod 755 "$path"
+#!/bin/bash
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+set -e
+export LC_ALL=C
+
+if [ "$(whoami)" != root ]; then
+	echo "Only root can do that"
+	exit 1
+fi
+
+if [ "$1" != --do-the-thing ]; then
+	echo "This script will generate new self-signed SSL certificates for KVMD Nginx"
+	echo "and put them to /etc/kvmd/nginx/ssl. If you're sure of what you're doing,"
+	echo "append the option '--do-the-thing' to execute. You can also append --vnc"
+	echo "to generate a certificate for VNC not for Nginx."
+	exit 1
+fi
+
+target=nginx
+if [ "$2" == --vnc ]; then
+	target=vnc
+fi
+path="/etc/kvmd/$target/ssl"
+
+set -e
+
+#Read Serial Number or use default all-zeros
+if read -r serialnumber </proc/device-tree/serial-number; then
+	serial="$serialnumber"
+else
+	serial="0000000000000000"
+fi
+
+san="DNS:pikvm-${serialnumber}.local"
+
+# Function to fetch IP addresses
+get_ip_addresses() {
+	ip address | awk '/inet / {print $2}' | cut -d/ -f1
+}
+
+# Try to get IP addresses
+ip_addresses=$(get_ip_addresses || true)
+set +e
+
+# Update SAN variable for IP certs
+for ip in $ip_addresses; do
+	san="${san},IP:${ip}"
+done
+
+set -x
+
+mkdir -p "$path"
+rm -f "$path"/*
+cd "$path"
+
+# Generate the OpenSSL configuration file for SAN
+cat >openssl.cnf <<EOL
+[ req ]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+
+[ req_distinguished_name ]
+C = RU
+ST = Moscow
+L = Moscow
+O = PiKVM
+OU = PiKVM
+CN = localhost
+
+[ v3_req ]
+subjectAltName = ${san}
+EOL
+
+# Generate the ECC key and self-signed certificate with SAN
+openssl ecparam -out server.key -name prime256v1 -genkey
+openssl req -new -x509 -sha256 -nodes -key server.key -out server.crt -days 3650 -config openssl.cnf
+
+chown "root:kvmd-$target" "$path"/*
+chmod 440 "$path/server.key"
+chmod 444 "$path/server.crt"
+chmod 755 "$path"
+
+# Clean up
+rm -f openssl.cnf

--- a/scripts/kvmd-gencert
+++ b/scripts/kvmd-gencert
@@ -45,12 +45,11 @@ path="/etc/kvmd/$target/ssl"
 set -e
 
 #Read Serial Number or use default all-zeros
-if read -r serialnumber </proc/device-tree/serial-number; then
-	serial="$serialnumber"
-else
-	serial="0000000000000000"
-fi
-
+get_serial_number() {
+    serialnumber=$(cat /proc/device-tree/serial-number 2>/dev/null || echo "0000000000000000")
+    echo "$serialnumber"
+}
+serial=$(get_serial_number)
 san="DNS:pikvm-${serial}.local"
 
 # Function to fetch IP addresses


### PR DESCRIPTION
This change is required to provide a Subject Alternate Name for the certificate rather than no SANs at all.  The default "localhost" is retained.  New certified IPs/hostnames include
- pikvm-${ProcessorSerialNumber}.local
- Ethernet IPv4 Address
- Ethernet IPv6 Address
- WiFi IPv4 Address (if connected)
- WiFi IPv6 Address (if connected)

This change allows a user to trust the PiKVM cert as a Root cert by default. After generating a cert with the `scripts/kvmd-gencert`, any acquired IPv4 and IPv6 addresses along with `pikvm-${ProcessorSerialNumber}` are registered as subject alternate names for the cert.   This allows the certificate to be used as a Trusted Root Certificate.

In Windows/Chrome
1.  show the certificate
![image](https://github.com/pikvm/kvmd/assets/527919/f98fa27d-c50d-42b6-98cb-f8b2e85f65ea)
2. Click Details, then Export then save to your Desktop.
![image](https://github.com/pikvm/kvmd/assets/527919/c353d278-042e-440e-9b2e-68b4a22021d0)
3. On the desktop double-click the file and then "Install Certificate..."
![image](https://github.com/pikvm/kvmd/assets/527919/ea890449-789d-4430-9292-d7dbaa040176)
4. Choose Current User, then next
![image](https://github.com/pikvm/kvmd/assets/527919/a905d8e3-cc77-4915-901f-86c64657370e)
5. Choose Place all certificates in the following store, then Browse...
![image](https://github.com/pikvm/kvmd/assets/527919/8d97a098-9fbc-4aca-adb4-f6372640daaf)
6. Press Trusted Root Certification Authorities, then Ok, and then Next
![image](https://github.com/pikvm/kvmd/assets/527919/516f3a76-5a19-4b02-bc90-a9647d1f8632)
7. Press Finish
![image](https://github.com/pikvm/kvmd/assets/527919/1640aaf0-4510-4017-9fe8-a80a3075e02d)
8. Press Yes, then Ok
![image](https://github.com/pikvm/kvmd/assets/527919/f5d49dfe-50b0-4e3c-92b3-47cef01299c8)
9. Close your browser completely, then reopen to your PiKVM.  The certificate is installed
![image](https://github.com/pikvm/kvmd/assets/527919/6faaa3d3-32a8-4261-baf4-ae0fc8306e97)


Possible Future improvements:
- make the IP or `pikvm-${ProcessorSerialNumber}` the official cert name instead of localhost. This will help to identify the certificates in the keystore.
- Create a certificate regeneration extras which runs this cert-genetator and restarts the webserver so that the user can recertify a dynamic IP address on-the-fly.