### PR TITLE
ps2: keyboard+mouse passthru support

### DIFF
--- a/hid/pico/Makefile
+++ b/hid/pico/Makefile
@@ -31,7 +31,7 @@ endef
 .tinyusb:
 	$(call libdep,tinyusb,hathach/tinyusb,d713571cd44f05d2fc72efc09c670787b74106e0)
 .ps2x2pico:
-	$(call libdep,ps2x2pico,No0ne/ps2x2pico,823260af57dcc55cf7cb96241346f51c065126de)
+	$(call libdep,ps2x2pico,No0ne/ps2x2pico,27c9bcede3370f0d4fdefea9c86a0eeb6170cf77)
 deps: .pico-sdk .tinyusb .ps2x2pico
 
 

--- a/hid/pico/src/CMakeLists.txt
+++ b/hid/pico/src/CMakeLists.txt
@@ -15,7 +15,8 @@ target_sources(${target_name} PRIVATE
 	ph_com_uart.c
 	ph_debug.c
 
-	${PS2_PATH}/ps2phy.c
+	${PS2_PATH}/ps2out.c
+	${PS2_PATH}/ps2in.c
 	${PS2_PATH}/ps2kb.c
 	${PS2_PATH}/ps2ms.c
 	${PS2_PATH}/scancodesets.c
@@ -24,7 +25,8 @@ target_link_options(${target_name} PRIVATE -Xlinker --print-memory-usage)
 target_compile_options(${target_name} PRIVATE -Wall -Wextra)
 target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${PS2_PATH})
 
-pico_generate_pio_header(${target_name} ${PS2_PATH}/ps2phy.pio)
+pico_generate_pio_header(${target_name} ${PS2_PATH}/ps2out.pio)
+pico_generate_pio_header(${target_name} ${PS2_PATH}/ps2in.pio)
 
 target_link_libraries(${target_name} PRIVATE
 	pico_stdlib

--- a/hid/pico/src/ph_ps2.c
+++ b/hid/pico/src/ph_ps2.c
@@ -32,6 +32,8 @@
 #define _KBD_DATA_PIN	11 // CLK == 12
 #define _MOUSE_DATA_PIN	14 // CLK == 15
 
+#define _KBD_IN_DATA_PIN 26 // passthru, CLK == 27
+#define _MOUSE_IN_DATA_PIN 16 // passthru, CLK == 17
 
 u8 ph_g_ps2_kbd_leds = 0;
 bool ph_g_ps2_kbd_online = 0;
@@ -57,13 +59,13 @@ void ph_ps2_init(void) {
 	}
 
 	if (PH_O_IS_KBD_PS2) {
-		kb_init(_KBD_DATA_PIN);
+		kb_init(_KBD_DATA_PIN, _KBD_IN_DATA_PIN);
 	} else {
 		INIT_STUB(_KBD_DATA_PIN);
 	}
 
 	if (PH_O_IS_MOUSE_PS2) {
-		ms_init(_MOUSE_DATA_PIN);
+		ms_init(_MOUSE_DATA_PIN, _MOUSE_IN_DATA_PIN);
 	} else {
 		INIT_STUB(_MOUSE_DATA_PIN);
 	}

--- a/hid/pico/src/ph_ps2.h
+++ b/hid/pico/src/ph_ps2.h
@@ -34,12 +34,12 @@ void ph_ps2_init(void);
 void ph_ps2_task(void);
 
 void tuh_kb_set_leds(u8 leds);
-void kb_init(u8 gpio);
+void kb_init(u8 gpio_out, u8 gpio_in);
 bool kb_task();
 void kb_send_key(u8 key, bool state, u8 modifiers);
 void ph_ps2_kbd_send_key(u8 key, bool state);
 
-void ms_init(u8 gpio);
+void ms_init(u8 gpio_out, u8 gpio_in);
 bool ms_task();
 void ms_send_movement(u8 buttons, s8 x, s8 y, s8 z);
 void ph_ps2_mouse_send_button(u8 button, bool state);


### PR DESCRIPTION
I'm still implementing this: https://github.com/pikvm/pikvm/issues/476
keyboard and mouse passthru should work :)

keyboard GPIOs are 26=data and 27=clock
mouse GPIOs are 16=data and 17=clock