### PR TITLE
Avoid infinite log spam if RTC device does not exist

### DIFF
--- a/kvmd/apps/watchdog/__init__.py
+++ b/kvmd/apps/watchdog/__init__.py
@@ -56,6 +56,8 @@ def _write_int(rtc: int, key: str, value: int) -> None:
 def _reset_alarm(rtc: int, timeout: int) -> None:
     try:
         now = _read_int(rtc, "since_epoch")
+    except FileNotFoundError:
+        raise RtcIsNotAvailableError("RTC device not found")
     except OSError as err:
         if err.errno != errno.EINVAL:
             raise


### PR DESCRIPTION
Some (unsupported) v3 clones don't have RTC, just accept your fate and stop trying forever to find it. This was probably always the intent, but a missing file is a FileNotFoundError and not an OSError since the OS is not at fault.

Fixes https://github.com/pikvm/pikvm/issues/678
Fixes https://github.com/pikvm/pikvm/issues/954

Otherwise, the log gets every couple of seconds a new entry
```
[2024-07-07 08:55:26 kvmd-watchdog.service] --- kvmd.apps.watchdog                INFO --- Running watchdog loop on RTC0 ...
[2024-07-07 08:55:26 kvmd-watchdog.service] --- Traceback (most recent call last):
[2024-07-07 08:55:26 kvmd-watchdog.service] ---   File "/usr/bin/kvmd-watchdog", line 8, in <module>
[2024-07-07 08:55:26 kvmd-watchdog.service] ---     sys.exit(main())
[2024-07-07 08:55:26 kvmd-watchdog.service] ---              ^^^^^^
[2024-07-07 08:55:26 kvmd-watchdog.service] ---   File "/usr/lib/python3.12/site-packages/kvmd/apps/watchdog/__init__.py", line 121, in main
[2024-07-07 08:55:26 kvmd-watchdog.service] ---     options.cmd(config.watchdog)
[2024-07-07 08:55:26 kvmd-watchdog.service] ---   File "/usr/lib/python3.12/site-packages/kvmd/apps/watchdog/__init__.py", line 82, in _cmd_run
[2024-07-07 08:55:26 kvmd-watchdog.service] ---     _reset_alarm(config.rtc, config.timeout)
[2024-07-07 08:55:26 kvmd-watchdog.service] ---   File "/usr/lib/python3.12/site-packages/kvmd/apps/watchdog/__init__.py", line 58, in _reset_alarm
[2024-07-07 08:55:26 kvmd-watchdog.service] ---     now = _read_int(rtc, "since_epoch")
[2024-07-07 08:55:26 kvmd-watchdog.service] ---           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2024-07-07 08:55:26 kvmd-watchdog.service] ---   File "/usr/lib/python3.12/site-packages/kvmd/apps/watchdog/__init__.py", line 47, in _read_int
[2024-07-07 08:55:26 kvmd-watchdog.service] ---     with open(_join_rtc(rtc, key)) as file:
[2024-07-07 08:55:26 kvmd-watchdog.service] ---          ^^^^^^^^^^^^^^^^^^^^^^^^^
[2024-07-07 08:55:26 kvmd-watchdog.service] --- FileNotFoundError: [Errno 2] No such file or directory: '/sys/class/rtc/rtc0/since_epoch'
[2024-07-07 08:55:30 kvmd-watchdog.service] --- kvmd.apps.watchdog                INFO --- Running watchdog loop on RTC0 ...
```