### PR TITLE
Proper manifest file for app mode

### DIFF
--- a/web/share/site.webmanifest
+++ b/web/share/site.webmanifest
@@ -1,6 +1,7 @@
 {
-	"name": "",
-	"short_name": "",
+	"name": "PiKVM",
+	"short_name": "PiKVM",
+	"start_url": "/",
 	"icons": [
 		{
 			"src": "/share/android-chrome-192x192.png",


### PR DESCRIPTION
Filling in the name and adding start_url will make browsers offer to install PiKVM as an application, including adding shortcuts to the start menu and everything. This runs it in app mode just like the instructions for running chrome with the --app flag.

Requires a valid SSL certificate be setup before browsers will show the option.