### PR TITLE
feat: prometheus metrics on separate http port

### DIFF
--- a/kvmd/apps/__init__.py
+++ b/kvmd/apps/__init__.py
@@ -752,6 +752,10 @@ def _get_config_scheme() -> dict:
                 "enabled": Option(True, type=valid_bool),
                 "port":    Option(443,  type=valid_port),
             },
+            "prometheus": {
+                "use_separate_port": Option(False, type=valid_bool),
+                "http_port":         Option(22091, type=valid_port),
+            },
         },
 
         "janus": {

--- a/kvmd/apps/ngxmkconf/__init__.py
+++ b/kvmd/apps/ngxmkconf/__init__.py
@@ -54,6 +54,8 @@ def main(argv: (list[str] | None)=None) -> None:
         https_enabled=config.nginx.https.enabled,
         https_port=config.nginx.https.port,
         ipv6_enabled=network.is_ipv6_enabled(),
+        prometheus_use_separate_port=config.nginx.prometheus.use_separate_port,
+        prometheus_http_port=config.nginx.prometheus.http_port,
     )
 
     if options.print:


### PR DESCRIPTION
Use case: pikvm exposed to internet via port forwarding, prometheus metrics scrapped in intranet without need to bother about authentication