### PR TITLE
Support NETRC to download files

### DIFF
--- a/kvmd/htclient.py
+++ b/kvmd/htclient.py
@@ -77,6 +77,7 @@ async def download(
             sock_connect=timeout,
             sock_read=(read_timeout if read_timeout is not None else timeout),
         ),
+        "trust_env": True,
     }
     async with aiohttp.ClientSession(**kwargs) as session:
         async with session.get(url, verify_ssl=verify) as response:


### PR DESCRIPTION
As it stands, kvmd does not use netrc to download files which makes downloading files off of site requiring authentication infeasible.

this commit adds the missing flag to let aiohttp use netrc for authetication