### PR TITLE
configuration option to disable the Info API's 'hw' and 'fan' sections

### DIFF
--- a/kvmd/apps/__init__.py
+++ b/kvmd/apps/__init__.py
@@ -393,6 +393,10 @@ def _get_config_scheme() -> dict:
                     "timeout":    Option(5.0, type=valid_float_f01),
                     "state_poll": Option(5.0, type=valid_float_f01),
                 },
+                "disabled": Option(
+                    [],
+                    type=functools.partial(valid_string_list), unpack_as="disabled",
+                ),
             },
 
             "log_reader": {

--- a/kvmd/apps/kvmd/info/__init__.py
+++ b/kvmd/apps/kvmd/info/__init__.py
@@ -39,9 +39,11 @@ class InfoManager:
             "auth": AuthInfoSubmanager(config.kvmd.auth.enabled),
             "meta": MetaInfoSubmanager(config.kvmd.info.meta),
             "extras": ExtrasInfoSubmanager(config),
-            "hw": HwInfoSubmanager(**config.kvmd.info.hw._unpack()),
-            "fan": FanInfoSubmanager(**config.kvmd.info.fan._unpack()),
         }
+        if not "hw" in config.kvmd.info.disabled:
+            self.__subs["hw"] = HwInfoSubmanager(**config.kvmd.info.hw._unpack())
+        if not "fan" in config.kvmd.info.disabled:
+            self.__subs["fan"] = FanInfoSubmanager(**config.kvmd.info.fan._unpack())
 
     def get_subs(self) -> set[str]:
         return set(self.__subs)


### PR DESCRIPTION
On my ancient board too many things are missing (no device-tree, missing sensors, never had a fan etc). To mitigate device-tree and temperature readings and errors, this configuration option can be used to disable it:

kvmd:
    info:
        disabled:
          - hw
          - fan

The error messages:

kvmd.apps.kvmd.info.hw           ERROR --- Can't read DT model from /proc/device-tree/model: [Errno 2] No such file or directory: '/proc/device-tree/model'
kvmd.apps.kvmd.info.hw           ERROR --- Can't read DT serial-number from /proc/device-tree/serial-number: [Errno 2] No such file or directory: '/proc/device-tree/serial-number'
kvmd.apps.kvmd.info.hw           ERROR --- Can't read CPU temp from /sys/class/thermal/thermal_zone0/temp: [Errno 2] No such file or directory: '/sys/class/thermal/thermal_zone0/temp'

