### PR TITLE
when a plugin name contains a dot, import it from the global space to…

### DIFF
--- a/kvmd/plugins/__init__.py
+++ b/kvmd/plugins/__init__.py
@@ -52,8 +52,14 @@ def get_plugin_class(sub: str, name: str) -> type[BasePlugin]:
     assert name
     if name.startswith("_"):
         raise UnknownPluginError(f"Unknown plugin '{sub}/{name}'")
-    try:
-        module = importlib.import_module(f"kvmd.plugins.{sub}.{name}")
-    except ModuleNotFoundError:
-        raise UnknownPluginError(f"Unknown plugin '{sub}/{name}'")
+    if "." in name:
+        try:
+            module = importlib.import_module( name )
+        except:
+            raise UnknownPluginError(f"Unknown plugin ' {name}'")
+    else:
+        try:
+            module = importlib.import_module(f"kvmd.plugins.{sub}.{name}")
+        except ModuleNotFoundError:
+            raise UnknownPluginError(f"Unknown plugin '{sub}/{name}'")
     return getattr(module, "Plugin")


### PR DESCRIPTION
Currently, the plugins (which is specified in the main.yaml) always be imported from the "kvmd.plugins." space. This small change enable to specify the full module path in the main.yaml to use off the tree code for 3rd party implementations.