### PR TITLE
ability to pass the kvmd instance to the plugin, because this will al…

### DIFF
--- a/kvmd/apps/kvmd/server.py
+++ b/kvmd/apps/kvmd/server.py
@@ -172,6 +172,7 @@ class KvmdServer(HttpServer):  # pylint: disable=too-many-arguments,too-many-ins
 
         self.__auth_manager = auth_manager
         self.__hid = hid
+        self.__atx = atx
         self.__streamer = streamer
         self.__snapshoter = snapshoter  # Not a component: No state or cleanup
 
@@ -209,6 +210,11 @@ class KvmdServer(HttpServer):  # pylint: disable=too-many-arguments,too-many-ins
         self.__streamer_notifier = aiotools.AioNotifier()
         self.__reset_streamer = False
         self.__new_streamer_params: dict = {}
+
+        if callable(getattr(hid,'set_parent', None)):
+            hid.set_parent(self)
+        if callable(getattr(atx,'set_parent', None)):
+            atx.set_parent(self)
 
     # ===== STREAMER CONTROLLER
 


### PR DESCRIPTION
Because in my case the both the HID and the ATX "functions" are provided by the same Arduino device, some modifications had been required to enable function calls between those two plugins. The least invasive ide for this, is to store the parent kvmd instance in the plugin, and thereafter, the plugin can now access the kvmd and it's variables. Because the _hid are already existed, i created a corresponding _atx too.