### PR TITLE
silence the systemd/dbus exception if there are no matching services

### DIFF
--- a/kvmd/apps/kvmd/sysunit.py
+++ b/kvmd/apps/kvmd/sysunit.py
@@ -75,6 +75,10 @@ class SystemdUnitInfo:
     async def close(self) -> None:
         try:
             if self.__bus is not None:
+                try:
+                    await self.__manager.call_get_default_target()
+                except:
+                    pass
                 self.__bus.disconnect()
                 await self.__bus.wait_for_disconnect()
         except Exception:


### PR DESCRIPTION
I got some strange dbus/systemd related exceptions when loading the landing page:

```
root                             ERROR --- add match request failed. match="sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',path='/org/freedesktop/DBus',member='NameOwnerChanged'", [Errno 32] Broken pipe
root                           WARNING --- a message handler threw an exception on shutdown
Traceback (most recent call last):
  File "/home/czo/opt/venv-312/pikvm/lib64/python3.12/site-packages/dbus_next/aio/message_bus.py", line 63, in write_callback
    self.offset += self.sock.send(self.buf[self.offset:])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
BrokenPipeError: [Errno 32] Broken pipe

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/czo/opt/venv-312/pikvm/lib64/python3.12/site-packages/dbus_next/message_bus.py", line 457, in _finalize
    handler(None, err)
  File "/home/czo/opt/venv-312/pikvm/lib64/python3.12/site-packages/dbus_next/message_bus.py", line 586, in reply_notify
    callback(reply, err)
  File "/home/czo/opt/venv-312/pikvm/lib64/python3.12/site-packages/dbus_next/message_bus.py", line 970, in add_match_notify
    if msg.message_type == MessageType.ERROR:
       ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'message_type'

```

I figured out, this will happens if the MessageBus connection was opened, but there are no matching service was found on my system and the connection will be closed without any function call. Clearing up the kvmd/extras folder will be too invasive to me, so i figured out, this exception will did not pop up if any systemd related function was called. So, getting the default target will solves the problem. I put it into a try:except block, because i did not know if it can or can not thorw an exception. Maybe, this is a bug in dbus_next?