### PR TITLE
Fix typo in switch warning pop up

### DIFF
--- a/web/share/js/kvm/atx.js
+++ b/web/share/js/kvm/atx.js
@@ -107,7 +107,7 @@ export function Atx(__recorder) {
 		if ($("atx-ask-switch").checked) {
 			wm.confirm(`
 				Are you sure you want to press the <b>${button}</b> button?<br>
-				Warning! This could case data loss on the server.
+				Warning! This could cause data loss on the server.
 			`).then(function(ok) {
 				if (ok) {
 					click_button();

--- a/web/share/js/kvm/switch.js
+++ b/web/share/js/kvm/switch.js
@@ -584,7 +584,7 @@ export function Switch() {
 		if ($("switch-atx-ask-switch").checked) {
 			wm.confirm(`
 				Are you sure you want to press the <b>${button}</b> button?<br>
-				Warning! This could case data loss on the server.
+				Warning! This could cause data loss on the server.
 			`).then(function(ok) {
 				if (ok) {
 					click_button();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/31d51015-9fdd-4934-b7e5-033693e169ce)
