### PR TITLE
web: disable autocomplete for 2fa

### DIFF
--- a/web/login/index.html
+++ b/web/login/index.html
@@ -75,7 +75,7 @@
             <tr>
               <td>2FA code:&nbsp;</td>
               <td>
-                <input id="code-input" type="text" placeholder="if enabled">
+                <input id="code-input" type="text" placeholder="if enabled" autocomplete="off">
               </td>
             </tr>
             <tr>

--- a/web/login/index.pug
+++ b/web/login/index.pug
@@ -37,7 +37,7 @@ block body
 						td #[input#passwd-input(type="password" autocapitalize="off")]
 					tr
 						td 2FA code:&nbsp;
-						td #[input#code-input(type="text" placeholder="if enabled")]
+						td #[input#code-input(type="text" placeholder="if enabled" autocomplete="off")]
 					tr
 						td(colspan=2) #[hr]
 					tr


### PR DESCRIPTION
Since 2FA codes are always changing, it is not helpful to have autocomplete suggestions for this field. It just displays a long list of outdated codes.

With the html attribute `autocomplete` this behaviour can be disabled. In my opinion that is always desired for the 2fa input.