### PR TITLE
Fixed OLED geometry detection logic for non-CM4 devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 *.pyc
 *.swp
 /venv/
+.DS_Store


### PR DESCRIPTION
On a Raspberry Pi Zero 2 W with a 128×64 OLED display, the screen was incorrectly initialized as 128×32 due to hardcoded logic relying solely on device model and USB presence. This caused display issues for non-CM4 boards with 64px-high screens.