### PR TITLE
Use `systemd-networkd-wait-online --any` by default

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -166,7 +166,9 @@ package_kvmd() {
 
 	install -Dm755 -t "$pkgdir/usr/bin" scripts/kvmd-{bootconfig,gencert,certbot}
 
-	install -Dm644 -t "$pkgdir/usr/lib/systemd/system" configs/os/services/*
+	install -dm755 "$pkgdir/usr/lib/systemd/system"
+	cp -rd configs/os/services -T "$pkgdir/usr/lib/systemd/system"
+
 	install -DTm644 configs/os/sysusers.conf "$pkgdir/usr/lib/sysusers.d/kvmd.conf"
 	install -DTm644 configs/os/tmpfiles.conf "$pkgdir/usr/lib/tmpfiles.d/kvmd.conf"
 

--- a/configs/os/services/systemd-networkd-wait-online.service.d/11-pikvm-wait-any.conf
+++ b/configs/os/services/systemd-networkd-wait-online.service.d/11-pikvm-wait-any.conf
@@ -1,0 +1,8 @@
+# Fix https://github.com/pikvm/pikvm/issues/1514:
+# Wait for any single network interface, not all configured ones
+# (Rationale: when user configures Wi-Fi via pikvm.txt or otherwise,
+#  we do not delete the Ethernet config, which means it will remain active
+#  regardless of whether the user ever intended to use Ethernet.)
+[Service]
+ExecStart=
+ExecStart=/usr/lib/systemd/systemd-networkd-wait-online --any


### PR DESCRIPTION
This means that `systemd-networkd-wait-online` (which is used when e.g. mounting remote filesystems via fstab) will only wait for the first (networkd-managed) interface to come up, not all of them. This properly ignores any networkd-unmanaged interfaces such as lo, tailscale0, WWAN modems or dynamically created otgnet ones.

This way, systemd-networkd-wait-online won't hang on boot for users who only have _some_ of the configured interfaces online/in use (which is the case for everyone who sets up Wi-Fi, since kvmd-bootconfig does not remove `eth0.network` even if it was never intended to be used).

We deem this semantics typical for Pi-KVM in general, thus the configuration override will be shipped as part of kvmd package. Users who _do_ need to wait for all interfaces to activate will have to countermand this drop-in manually.

Fixes pikvm/pikvm#1514.