### PR TITLE
Custom auth flow support and OAuth2/OIDC plugin

### DIFF
--- a/kvmd/apps/_scheme.py
+++ b/kvmd/apps/_scheme.py
@@ -26,6 +26,7 @@ from ..tools import walk_dict
 from ..tools import is_dict
 
 from ..plugins.auth import get_auth_service_class
+from ..plugins.oauth import get_oauth_provider_class
 from ..plugins.hid import get_hid_class
 from ..plugins.atx import get_atx_class
 from ..plugins.msd import get_msd_class
@@ -50,7 +51,6 @@ from ..validators.basic import valid_int_f1
 from ..validators.basic import valid_float_f0
 from ..validators.basic import valid_float_f01
 from ..validators.basic import valid_string_list
-from ..validators.basic import valid_dict
 
 from ..validators.auth import valid_user
 from ..validators.auth import valid_users_list
@@ -178,12 +178,32 @@ def patch_dynamic(  # pylint: disable=too-many-locals
     if load_all:
         load_auth = load_hid = load_atx = load_msd = load_gpio = True
 
+    if load_gpio or load_auth:
+        raw = copy.deepcopy(main)
+        yaml_merge(raw, override)
+
     rebuild = False
 
     if load_auth:
         scheme["kvmd"]["auth"]["internal"].update(get_auth_service_class(config.kvmd.auth.internal.type).get_plugin_options())
         if config.kvmd.auth.external.type:
             scheme["kvmd"]["auth"]["external"].update(get_auth_service_class(config.kvmd.auth.external.type).get_plugin_options())
+        if config.kvmd.auth.flows:
+            for (flow, params) in walk_dict(raw, "kvmd", "auth", "flows").items():
+                scheme["kvmd"]["auth"]["flows"][flow] = {
+                    "enabled":   Option(False, type=valid_bool),
+                    "providers": {},  # Dynamic content
+                }
+                # FIXME: dirty, OAuth details leak into generic code
+                # XXX: how does this interact with dynamic schema keys code that I wrote?
+                if flow == "oauth" and params.get("enabled"):
+                    for (provider, params) in walk_dict(params, "providers").items():
+                        provider_type = valid_stripped_string_not_empty(params.get("type", "oauth2"))
+                        provider_class = get_oauth_provider_class(provider_type)
+                        scheme["kvmd"]["auth"]["flows"][flow]["providers"][provider] = {
+                            "type": Option(provider_type, type=valid_stripped_string_not_empty),
+                            **provider_class.get_plugin_options(),
+                        }
         rebuild = True
 
     for (load, section, get_class) in [
@@ -196,9 +216,6 @@ def patch_dynamic(  # pylint: disable=too-many-locals
             rebuild = True
 
     if load_gpio:
-        raw = copy.deepcopy(main)
-        yaml_merge(raw, override)
-
         driver: str
         drivers: dict[str, type[BaseUserGpioDriver]] = {}  # Name to drivers
         for (driver, params) in {  # type: ignore
@@ -324,11 +341,12 @@ def make_config_scheme() -> dict:
                 },
 
                 "flows": {
-                    # Dynamic content ("oauth", ...)
+                    # Dynamic content
                     Dynamic(): {
-                        "enabled": Option(False, type=valid_bool),
-                        Dynamic(): Option({}, type=valid_dict),
-                        # Dynamic content ("providers" for oauth, ...)
+                        "enabled":   Option(False, type=valid_bool),
+                        "providers": {
+                            # Dynamic content
+                        },
                     }
                 },
             },

--- a/kvmd/apps/_scheme.py
+++ b/kvmd/apps/_scheme.py
@@ -37,6 +37,7 @@ from ..plugins.ugpio import get_ugpio_driver_class
 from ..yamlconf import Hint
 from ..yamlconf import Option
 from ..yamlconf import Section
+from ..yamlconf import Dynamic
 from ..yamlconf import manual_validated
 from ..yamlconf.merger import yaml_merge
 
@@ -49,6 +50,7 @@ from ..validators.basic import valid_int_f1
 from ..validators.basic import valid_float_f0
 from ..validators.basic import valid_float_f01
 from ..validators.basic import valid_string_list
+from ..validators.basic import valid_dict
 
 from ..validators.auth import valid_user
 from ..validators.auth import valid_users_list
@@ -319,6 +321,15 @@ def make_config_scheme() -> dict:
                     "secret": {
                         "file": Option("/etc/kvmd/totp.secret", type=valid_abs_path, if_empty=""),
                     },
+                },
+
+                "flows": {
+                    # Dynamic content ("oauth", ...)
+                    Dynamic(): {
+                        "enabled": Option(False, type=valid_bool),
+                        Dynamic(): Option({}, type=valid_dict),
+                        # Dynamic content ("providers" for oauth, ...)
+                    }
                 },
             },
 

--- a/kvmd/apps/kvmd/__init__.py
+++ b/kvmd/apps/kvmd/__init__.py
@@ -78,6 +78,12 @@ def main() -> None:
             force_int_users=config.auth.internal.force_users,
 
             totp_secret_path=config.auth.totp.secret.file,
+
+            flows={
+                k: v._unpack(ignore=["enabled"]) if v.enabled else None
+                for k, v
+                in config.auth.flows.items()
+            },
         ),
         im=InfoManager(global_config),
         log_reader=(LogReader() if config.log_reader.enabled else None),

--- a/kvmd/apps/kvmd/api/auth.py
+++ b/kvmd/apps/kvmd/api/auth.py
@@ -177,8 +177,7 @@ class AuthApi:
     @exposed_http("GET", "/auth/flow/{name}/{subpath:.+}", auth_required=False, allow_usc=False)
     async def __flow_req_handler(self, req: Request) -> Response:
         name = req.match_info["name"]
-        subpath = req.match_info["subpath"]
         plugin = self.__auth.flow_managers.get(name)
         if plugin is None:
             raise HTTPNotFound(reason=f"Auth method \"{name}\" does not exist")
-        return await plugin.dispatch(req, subpath)
+        return await plugin.dispatch(req, None)

--- a/kvmd/apps/kvmd/api/auth.py
+++ b/kvmd/apps/kvmd/api/auth.py
@@ -22,9 +22,12 @@
 
 import base64
 
+from typing import Any
+
 from aiohttp.web import Request
 from aiohttp.web import Response
 from aiohttp.web import HTTPFound
+from aiohttp.web import HTTPNotFound
 
 from ....htserver import UnauthorizedError
 from ....htserver import ForbiddenError
@@ -148,3 +151,34 @@ class AuthApi:
     @exposed_http("GET", "/auth/check", allow_usc=False)
     async def __check_handler(self, _: Request) -> Response:
         return make_json_response()
+
+    @exposed_http("GET", "/auth/flows", auth_required=False, allow_usc=False)
+    async def __flows_list_handler(self, _: Request) -> Response:
+        return make_json_response(result={
+            "flows": list(self.__auth.flow_managers.keys()),
+        })
+
+    @exposed_http("GET", "/auth/flow/{name}/check", auth_required=False, allow_usc=False)
+    async def __flow_check_handler(self, req: Request) -> Response:
+        name = req.match_info["name"]
+        plugin = self.__auth.flow_managers.get(name)
+        response: dict[str, Any] = {}
+        if plugin is None:
+            response.update({"enabled": False})
+        else:
+            response.update({"enabled": True})
+            # TODO: perhaps invoke the flow plugin for additional data
+            #       and merge this handler with OAuth-specific /auth/flow/oauth/providers?
+            #       (see oauth.Plugin.__oauth_providers())
+            # response |= await plugin.check(req)
+        response["available"] = response["enabled"]
+        return make_json_response(result=response)
+
+    @exposed_http("GET", "/auth/flow/{name}/{subpath:.+}", auth_required=False, allow_usc=False)
+    async def __flow_req_handler(self, req: Request) -> Response:
+        name = req.match_info["name"]
+        subpath = req.match_info["subpath"]
+        plugin = self.__auth.flow_managers.get(name)
+        if plugin is None:
+            raise HTTPNotFound(reason=f"Auth method \"{name}\" does not exist")
+        return await plugin.dispatch(req, subpath)

--- a/kvmd/apps/kvmd/api/auth.py
+++ b/kvmd/apps/kvmd/api/auth.py
@@ -45,7 +45,6 @@ from ....validators.auth import valid_auth_token
 
 from ..auth import AuthManager
 
-
 # =====
 _COOKIE_AUTH_TOKEN = "auth_token"
 

--- a/kvmd/apps/kvmd/auth.py
+++ b/kvmd/apps/kvmd/auth.py
@@ -36,6 +36,9 @@ from ...yamlconf import Section
 from ...plugins.auth import BaseAuthService
 from ...plugins.auth import get_auth_service_class
 
+from ...plugins.flows import BaseAuthFlowService
+from ...plugins.flows import get_auth_flow_service_class
+
 from ...htserver import HttpExposed
 from ...htserver import RequestUnixCredentials
 
@@ -55,7 +58,7 @@ class _Session:
         assert self.expire_ts >= 0
 
 
-class AuthManager:  # pylint: disable=too-many-arguments,too-many-instance-attributes
+class AuthManager:  # pylint: disable=too-many-arguments,too-many-instance-attributes,too-many-locals
     def __init__(
         self,
         enabled: bool,
@@ -71,6 +74,8 @@ class AuthManager:  # pylint: disable=too-many-arguments,too-many-instance-attri
         force_int_users: list[str],
 
         totp_secret_path: str,
+
+        flows: dict[str, dict | None],
     ) -> None:
 
         logger = get_logger(0)
@@ -112,6 +117,14 @@ class AuthManager:  # pylint: disable=too-many-arguments,too-many-instance-attri
             self.__ext_service = get_auth_service_class(ext_c.type)(ext_c)
             logger.info("Using external auth service %r",
                         self.__ext_service.get_plugin_name())
+
+        self.flow_managers: dict[str, BaseAuthFlowService] = {}
+        for flow, flow_kwargs in flows.items():
+            if flow_kwargs is not None:
+                get_logger().info("Using custom auth flow service %r", flow)
+                self.flow_managers[flow] = get_auth_flow_service_class(flow)(manager=self, **flow_kwargs)
+            else:
+                get_logger().info("Custom auth flow service %r is disabled in config", flow)
 
         self.__totp_secret_path = totp_secret_path
 
@@ -164,14 +177,7 @@ class AuthManager:  # pylint: disable=too-many-arguments,too-many-instance-attri
         assert self.__enabled
 
         if (await self.authorize(user, passwd)):
-            token = self.__make_new_token()
-            session = _Session(
-                user=user,
-                expire_req=expire,
-                expire_ts=self.__make_expire_ts(expire),
-                ws_started=0,
-            )
-            self.__sessions[token] = session
+            session, token = self.__create_session(user, expire)
             get_logger(0).info("Logged in user %r; expire=%s, sessions_now=%d",
                                session.user,
                                self.__format_expire_ts(session.expire_ts),
@@ -179,6 +185,29 @@ class AuthManager:  # pylint: disable=too-many-arguments,too-many-instance-attri
             return token
 
         return None
+
+    async def login_external(self, user: str) -> (str | None):
+        assert user == user.strip()
+        assert user
+        assert self.__enabled
+
+        session, token = self.__create_session(user, 0)
+        get_logger(0).info("Logged in user %r externally; expire=%s, sessions_now=%d",
+                           session.user,
+                           self.__format_expire_ts(session.expire_ts),
+                           self.__get_sessions_number(session.user))
+        return token
+
+    def __create_session(self, user: str, expire: int) -> tuple[_Session, str]:
+        token = self.__make_new_token()
+        session = _Session(
+            user=user,
+            expire_req=expire,
+            expire_ts=self.__make_expire_ts(expire),
+            ws_started=0,
+        )
+        self.__sessions[token] = session
+        return session, token
 
     def __make_new_token(self) -> str:
         for _ in range(10):

--- a/kvmd/apps/kvmd/router.py
+++ b/kvmd/apps/kvmd/router.py
@@ -52,9 +52,13 @@ class HttpRouter(HttpRouterBase):
     def add_exposed(self, *objs: object) -> None:
         self._add_exposed(*objs)
 
-    async def dispatch(self, req: Request, subpath: str) -> Response:
+    async def dispatch(self, req: Request, subpath: str | None) -> Response:
         assert self._app is not None
-        subreq = req.clone(rel_url='/' + subpath.removeprefix('/'))
+        subreq = (
+            req.clone(rel_url="/" + subpath.removeprefix("/"))
+            if subpath is not None
+            else req.clone()
+        )
         match_info = await self._app.router.resolve(subreq)
         if match_info.handler is None:
             # XXX can this happen?

--- a/kvmd/apps/kvmd/router.py
+++ b/kvmd/apps/kvmd/router.py
@@ -1,0 +1,72 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2025 Ivan Shapovalov <intelfx@intelfx.name>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+import asyncio
+
+from typing import cast
+
+from aiohttp.web import Application
+from aiohttp.web import HTTPNotFound
+
+from aiohttp.web import Request
+from aiohttp.web import Response
+
+from ...logging import get_logger
+
+from ...htserver import HttpExposed
+from ...htserver import HttpRouterBase
+
+from .auth import AuthManager
+from .api.auth import check_request_auth
+
+
+class HttpRouter(HttpRouterBase):
+    def __init__(self, auth: AuthManager) -> None:
+        super().__init__()
+        self.__auth = auth
+        self._app = Application(
+            loop=None,
+        )
+
+    # =====
+
+    def add_exposed(self, *objs: object) -> None:
+        self._add_exposed(*objs)
+
+    async def dispatch(self, req: Request, subpath: str) -> Response:
+        assert self._app is not None
+        subreq = req.clone(rel_url='/' + subpath.removeprefix('/'))
+        match_info = await self._app.router.resolve(subreq)
+        if match_info.handler is None:
+            # XXX can this happen?
+            get_logger().error(
+                "Unexpected: nested router for %r: no handler in %r",
+                subreq.path, match_info,
+            )
+            raise HTTPNotFound()
+        subreq._match_info = match_info  # pylint: disable=protected-access  # noqa: vulture-ignore
+        return cast(Response, await match_info.handler(subreq))
+
+    # =====
+
+    async def _check_request_auth(self, exposed: HttpExposed, req: Request) -> None:
+        return await check_request_auth(self.__auth, exposed, req)

--- a/kvmd/apps/kvmd/router.py
+++ b/kvmd/apps/kvmd/router.py
@@ -55,7 +55,7 @@ class HttpRouter(HttpRouterBase):
     async def dispatch(self, req: Request, subpath: str | None) -> Response:
         assert self._app is not None
         subreq = (
-            req.clone(rel_url="/" + subpath.removeprefix("/"))
+            req.clone(rel_url="/" + subpath.lstrip("/"))
             if subpath is not None
             else req.clone()
         )

--- a/kvmd/htserver.py
+++ b/kvmd/htserver.py
@@ -349,8 +349,43 @@ class WsSession:
         await self.wsr.send_bytes(data)
 
 
-class HttpServer:
+class HttpRouterBase:
     def __init__(self) -> None:
+        self._app: Application | None = None
+
+    # =====
+
+    def _add_exposed(self, *objs: object) -> None:
+        for obj in objs:
+            for http_exposed in _get_exposed_http(obj):
+                self.__add_exposed_http(http_exposed)
+
+    def __add_exposed_http(self, exposed: HttpExposed) -> None:
+        assert self._app is not None
+
+        async def wrapper(req: Request) -> Response:
+            try:
+                await self._check_request_auth(exposed, req)
+                return (await exposed.handler(req))
+            except IsBusyError as ex:
+                return make_json_exception(ex, 409)
+            except (ValidatorError, OperationError) as ex:
+                return make_json_exception(ex, 400)
+            except HttpError as ex:
+                return make_json_exception(ex)
+        self._app.router.add_route(exposed.method, exposed.path, wrapper)
+
+    # =====
+
+    async def _check_request_auth(self, exposed: HttpExposed, req: Request) -> None:
+        pass
+
+    # =====
+
+
+class HttpServer(HttpRouterBase):
+    def __init__(self) -> None:
+        super().__init__()
         self.__ws_heartbeat: (float | None) = None
         self.__ws_handlers: dict[str, Callable] = {}
         self.__ws_bin_handlers: dict[int, Callable] = {}
@@ -386,24 +421,10 @@ class HttpServer:
     # =====
 
     def _add_exposed(self, *objs: object) -> None:
+        super()._add_exposed(*objs)
         for obj in objs:
-            for http_exposed in _get_exposed_http(obj):
-                self.__add_exposed_http(http_exposed)
             for ws_exposed in _get_exposed_ws(obj):
                 self.__add_exposed_ws(ws_exposed)
-
-    def __add_exposed_http(self, exposed: HttpExposed) -> None:
-        async def wrapper(req: Request) -> Response:
-            try:
-                await self._check_request_auth(exposed, req)
-                return (await exposed.handler(req))
-            except IsBusyError as ex:
-                return make_json_exception(ex, 409)
-            except (ValidatorError, OperationError) as ex:
-                return make_json_exception(ex, 400)
-            except HttpError as ex:
-                return make_json_exception(ex)
-        self.__app.router.add_route(exposed.method, exposed.path, wrapper)
 
     def __add_exposed_ws(self, exposed: WsExposed) -> None:
         if exposed.binary:
@@ -518,7 +539,7 @@ class HttpServer:
     async def __make_app(self) -> Application:
         await self._before_app()
 
-        self.__app = Application(middlewares=[normalize_path_middleware(  # pylint: disable=attribute-defined-outside-init
+        self._app = Application(middlewares=[normalize_path_middleware(
             append_slash=False,
             remove_slash=True,
             merge_slashes=True,
@@ -526,14 +547,14 @@ class HttpServer:
 
         async def on_shutdown(_: Application) -> None:
             await self._on_shutdown()
-        self.__app.on_shutdown.append(on_shutdown)
+        self._app.on_shutdown.append(on_shutdown)
 
         async def on_cleanup(_: Application) -> None:
             await self._on_cleanup()
-        self.__app.on_cleanup.append(on_cleanup)
+        self._app.on_cleanup.append(on_cleanup)
 
         await self._init_app()
-        return self.__app
+        return self._app
 
     def __run_app_print(self, text: str) -> None:
         logger = get_logger(0)

--- a/kvmd/plugins/flows/__init__.py
+++ b/kvmd/plugins/flows/__init__.py
@@ -1,0 +1,52 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2025 Ivan Shapovalov <intelfx@intelfx.name>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+from typing import Any
+from typing import TYPE_CHECKING
+
+from aiohttp.web import Request
+from aiohttp.web import Response
+
+from .. import BasePlugin
+from .. import get_plugin_class
+
+if TYPE_CHECKING:
+    from ...apps.kvmd import AuthManager
+
+
+# =====
+# FIXME: perhaps we want to have a BaseRouterPlugin (see dispatch() and its impl in oauth.Plugin)?
+class BaseAuthFlowService(BasePlugin):
+    # FIXME: should be able to use a Protocol here instead of declaring a ctor that does nothing
+    #        and only exists to define the proper signature of descendant constructors,
+    #        but you can't express "type that both implements a protocol A and is a subclass of B"
+    # pylint: disable=super-init-not-called,unused-argument
+    def __init__(self, *, manager: "AuthManager", **_: Any) -> None:
+        pass
+
+    async def dispatch(self, req: Request, subpath: str | None = None) -> Response:
+        raise NotImplementedError
+
+
+# =====
+def get_auth_flow_service_class(name: str) -> type[BaseAuthFlowService]:
+    return get_plugin_class("flows", name)  # type: ignore

--- a/kvmd/plugins/flows/oauth.py
+++ b/kvmd/plugins/flows/oauth.py
@@ -123,7 +123,8 @@ class OAuthApi:
         if not self.__plugin.is_redirect_from_provider(provider=provider, request_query=dict(request.query)):
             raise HTTPUnauthorized(reason="Authorization Code is missing")
 
-        redirect_url = request.url.with_path(f"/api/auth/oauth/callback/{provider}").with_scheme("https")
+        # FIXME: why is this not just redirect_url = request.url?
+        redirect_url = request.url.with_path(f"/api/auth/flow/oauth/callback/{provider}").with_scheme("https")
         # FIXME: better exception handling, this throws OAuthError if the inner subrequest fails
         try:
             user = await self.__plugin.get_user_info(

--- a/kvmd/plugins/flows/oauth.py
+++ b/kvmd/plugins/flows/oauth.py
@@ -1,0 +1,334 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                  2024-2024  Markus Beckschulte (SLA/RWTH Aachen)           #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+import base64
+import json
+from typing import Any
+from typing import Self
+
+from aiohttp.web import Request
+from aiohttp.web import Response
+from aiohttp.web import HTTPFound
+from aiohttp.web import HTTPNotFound
+from aiohttp.web import HTTPUnauthorized
+
+from cryptography import fernet
+from cryptography.fernet import InvalidToken
+from yarl import URL
+
+from ...htserver import ForbiddenError
+from ...htserver import exposed_http
+from ...htserver import make_json_response
+
+from ...validators.auth import valid_user
+
+from ...apps.kvmd.router import HttpRouter
+from ...apps.kvmd.auth import AuthManager
+from ...apps.kvmd.api.auth import _COOKIE_AUTH_TOKEN
+
+from ..oauth import BaseOAuthProvider, get_oauth_provider_class
+from . import BaseAuthFlowService
+
+
+_COOKIE_OAUTH_SESSION = "oauth_session"
+
+
+class OAuthApi:
+    def __init__(self, plugin: "Plugin"):
+        self.__plugin: "Plugin" = plugin
+
+    @exposed_http("GET", "/auth/flow/oauth/providers", auth_required=False, allow_usc=False)
+    async def __oauth_providers(self, _: Request) -> Response:
+        """
+        Return a json containing the available Providers with short_name and long_name and if oauth is enabled
+        @param request:
+        @return: json with provider infos
+        """
+        response: dict[str, (bool | dict)] = {}
+        if self.__plugin is None:
+            response.update({"enabled": False})
+        else:
+            response.update({"enabled": True, "providers": self.__plugin.get_providers()})
+        return make_json_response(response)
+
+    @exposed_http("GET", "/auth/flow/oauth/login/{provider}", auth_required=False, allow_usc=False)
+    async def __oauth(self, request: Request) -> None:
+        """
+        Creates the redirect to the Provider specified in the URL. Checks if the provider is valid.
+        Also sets a cookie containing session information.
+        @param request:
+        @return: redirect to provider
+        """
+        provider = format(request.match_info["provider"])
+        if not self.__plugin.valid_provider(provider):
+            raise HTTPNotFound(reason="Unknown provider %s" % provider)
+
+        redirect_url = request.url.with_path(f"/api/auth/flow/oauth/callback/{provider}").with_scheme("https")
+        oauth_cookie = request.cookies.get(_COOKIE_OAUTH_SESSION, "")
+
+        is_valid_session = await self.__plugin.is_valid_session(provider, oauth_cookie)
+        if not is_valid_session:
+            session = await self.__plugin.register_new_session(provider)
+        else:
+            session = oauth_cookie
+
+        response = HTTPFound(
+            await self.__plugin.get_authorize_url(
+                provider=provider, redirect_url=redirect_url, session=session,
+            )
+        )
+        response.set_cookie(name=_COOKIE_OAUTH_SESSION, value=session, secure=True, httponly=True, samesite="Lax")
+
+        # 302 redirect to provider:
+        raise response
+
+    @exposed_http("GET", "/auth/flow/oauth/callback/{provider}", auth_required=False, allow_usc=False)
+    async def __callback(self, request: Request) -> Response:
+        """
+        After successful login on the side of the provider, the user gets redirected here. If everything is correct,
+        the user gets logged in with the username provided by the Provider.
+        @param request:
+        @return:
+        """
+        if not request.match_info["provider"]:
+            raise HTTPUnauthorized(reason="Provider is missing")
+        provider = format(request.match_info["provider"])
+        if not self.__plugin.valid_provider(provider):
+            raise HTTPNotFound(reason="Unknown provider %s" % provider)
+
+        if _COOKIE_OAUTH_SESSION not in request.cookies.keys():
+            raise HTTPUnauthorized(reason="Cookie is missing")
+        oauth_session = request.cookies[_COOKIE_OAUTH_SESSION]
+
+        if not self.__plugin.is_redirect_from_provider(provider=provider, request_query=dict(request.query)):
+            raise HTTPUnauthorized(reason="Authorization Code is missing")
+
+        redirect_url = request.url.with_path(f"/api/auth/oauth/callback/{provider}").with_scheme("https")
+        user = await self.__plugin.get_user_info(
+            provider=provider,
+            oauth_session=oauth_session,
+            request_query=dict(request.query),
+            redirect_url=redirect_url
+        )
+        if not user:
+            raise ForbiddenError()
+
+        # pylint: disable=protected-access
+        token = await self.__plugin._manager.login_external(
+            user=valid_user(user)
+        )
+        if not token:
+            raise ForbiddenError()
+
+        response = HTTPFound(
+            request.url.with_path("").with_scheme("https")
+        )
+        response.set_cookie(name=_COOKIE_AUTH_TOKEN, value=token, samesite="Lax", httponly=True)
+        return response
+
+
+class Plugin(BaseAuthFlowService):
+    # pylint: disable=super-init-not-called
+    def __init__(self, *, manager: AuthManager, providers: dict) -> None:
+        """
+        Initializes the OAuth authentication flow plugin.
+        1. Creates OAuthSessionStorage with a random key
+        2. Iterates over the providers and initializes them
+        @param manager: the AuthManager instance
+        @param providers: the configured providers
+        """
+        self._manager: AuthManager = manager
+        self.__api: OAuthApi = OAuthApi(self)
+        self.__router: HttpRouter = HttpRouter(manager)
+        self.__session_storage: OAuthSessionStorage = OAuthSessionStorage(fernet.Fernet.generate_key())
+        self.__providers: dict[str, BaseOAuthProvider] = {}
+
+        self.__router.add_exposed(self.__api)
+
+        for provider, data in providers.items():
+            # TODO: this is ad-hoc schema validation, refactor this and extract schema
+            service_type = data.pop("type")
+            self.__providers.update({
+                provider: get_oauth_provider_class(service_type)(**data)
+            })
+
+    def api(self) -> object:
+        return self.__api
+
+    async def dispatch(self, req: Request, subpath: str | None = None) -> Response:
+        return await self.__router.dispatch(req, subpath)
+
+    def valid_provider(self, provider: str) -> bool:
+        """
+        checks if the given provider exists.
+        @param provider: provider to be checked
+        @return: True: provider exists
+        """
+        return provider in self.__providers
+
+    def get_providers(self) -> dict[str, str]:  # short_name: long_name
+        """
+        Returns a dict mapping the short_name of a provider to the long_name
+        @return: dict short_name: long_name
+        """
+        ret = {}
+        for short_name, provider in self.__providers.items():
+            ret[short_name] = provider.get_long_name()
+        return ret
+
+    def is_redirect_from_provider(self, provider: str, request_query: dict) -> bool:
+        """
+        Delegates the request_query to the appropriate provider and returns its response.
+        @param provider: provider this is meant for
+        @param request_query: the request_query
+        @return: True: is a redirect from provider
+        """
+        return self.__providers[provider].is_redirect_from_provider(request_query)
+
+    async def get_authorize_url(self, provider: str, redirect_url: URL, session: str) -> str:
+        """
+        Lets the appropriate provider form an authorize URL the user should be redirected to
+        @param provider: provider this is meant for
+        @param redirect_url: the URL the user should be redirected to after successful login
+        @param session: the oauth_session cookie
+        @return: authorization URL, or authorization code request
+        """
+        session_decrypted = await self.__session_storage.get_session_data(session)
+        return self.__providers[provider].get_authorize_url(
+            redirect_url=redirect_url,
+            session=session_decrypted,
+        )
+
+    async def get_user_info(
+            self,
+            provider: str,
+            oauth_session: str,
+            request_query: dict,
+            redirect_url: URL
+    ) -> str:
+        """
+        Returns the Username it gets by the provider
+        @param provider: provider this is meant for
+        @param oauth_session: the encrypted oauth_session cookie
+        @param request_query: the query of the request
+        @param redirect_url: the redirect URL the used with get_authorize_url
+        @return:
+        """
+        session = await self.__session_storage.get_session_data(oauth_session)
+        return await self.__providers[provider].get_user_info(
+            oauth_session=session,
+            request_query=request_query,
+            redirect_url=redirect_url
+        )
+
+    async def register_new_session(self, provider: str) -> str:
+        """
+        Registers a new session and returns it.
+        @param provider: provider this is meant for
+        @return: the new encrypted session
+        """
+        provider_session_data = self.__providers[provider].register_new_session()
+        session = await self.__session_storage.set_session_data(provider_session_data)
+        return session
+
+    async def is_valid_session(self, provider: str, session: str) -> bool:
+        """
+        Checks if the provided session is valid.
+        @param provider: provider this is meant for
+        @param session: the encrypted oauth_session
+        @return: True: is valid session
+        """
+        if session == "":
+            return False
+        try:
+            session_data = await self.__session_storage.get_session_data(session)
+        except InvalidToken:
+            return False
+        return self.__providers[provider].is_valid_session(session_data)
+
+
+class OAuthSessionStorage:
+    def __init__(self, secure_key: bytes):
+        """
+        Initiates a new OAuthSessionStorage and stores the cipher.
+        @param secure_key: bytes to generate the cipher
+        """
+        self.__cipher = fernet.Fernet(secure_key)
+
+    async def __encrypt_data(self, data: str) -> str:
+        """
+        encrypts the given session
+        @param data: the session represented by a string
+        @return: encrypted session
+        """
+        encrypted_data = self.__cipher.encrypt(data.encode())
+        return base64.urlsafe_b64encode(encrypted_data).decode()
+
+    async def __decrypt_data(self, encrypted_data: str) -> str:
+        """
+        Decrypts a session to a string representation
+        @param encrypted_data: the encrypted session
+        @return: decrypted session as string
+        """
+        decrypted_data = self.__cipher.decrypt(base64.urlsafe_b64decode(encrypted_data)).decode()
+        return decrypted_data
+
+    async def set_session_data(self, data: dict) -> str:
+        """
+        Encrypts a dict and returns its representation as string
+        @param data: the session to encrypt
+        @return: encrypted session
+        """
+        encrypted_data = await self.__encrypt_data(json.dumps(data))
+        return encrypted_data
+
+    async def get_session_data(self, oauth_cookie: str) -> dict:
+        """
+        decrypts a given session to a dict
+        @param oauth_cookie: the encrypted session
+        @return: the decrypted session
+        """
+        if oauth_cookie:
+            decrypted_data = await self.__decrypt_data(oauth_cookie)
+            return json.loads(decrypted_data)
+        else:
+            return {}
+
+    async def logout(self, token: str) -> None:
+        pass
+
+
+class User:
+    def __init__(self, user_name: str, provider: BaseOAuthProvider):
+        self.__provider: BaseOAuthProvider = provider  # noqa: vulture-ignore
+        self.__provider_data: Any  # noqa: vulture-ignore
+        self.__user_name: str = user_name
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, User):  # because of this, we will be able "access a protected member"
+            return self.__user_name == other.__user_name  # pylint: disable=W0212
+        return False
+
+    def __getitem__(self, item: Any) -> Self | None:
+        if item == self.__user_name:
+            return self
+        return None

--- a/kvmd/plugins/flows/oauth.py
+++ b/kvmd/plugins/flows/oauth.py
@@ -46,6 +46,7 @@ from ...apps.kvmd.auth import AuthManager
 from ...apps.kvmd.api.auth import _COOKIE_AUTH_TOKEN
 
 from ..oauth import BaseOAuthProvider, get_oauth_provider_class
+from ..oauth import OAuthError
 from . import BaseAuthFlowService
 
 
@@ -123,12 +124,16 @@ class OAuthApi:
             raise HTTPUnauthorized(reason="Authorization Code is missing")
 
         redirect_url = request.url.with_path(f"/api/auth/oauth/callback/{provider}").with_scheme("https")
-        user = await self.__plugin.get_user_info(
-            provider=provider,
-            oauth_session=oauth_session,
-            request_query=dict(request.query),
-            redirect_url=redirect_url
-        )
+        # FIXME: better exception handling, this throws OAuthError if the inner subrequest fails
+        try:
+            user = await self.__plugin.get_user_info(
+                provider=provider,
+                oauth_session=oauth_session,
+                request_query=dict(request.query),
+                redirect_url=redirect_url
+            )
+        except OAuthError as e:
+            raise HTTPUnauthorized(reason=f"OAuth error: {e}")
         if not user:
             raise ForbiddenError()
 

--- a/kvmd/plugins/oauth/__init__.py
+++ b/kvmd/plugins/oauth/__init__.py
@@ -1,0 +1,65 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+from yarl import URL  # FIXME: remove this
+
+from .. import BasePlugin
+from .. import get_plugin_class
+
+
+# =====
+class OAuthError(Exception):
+    pass
+
+
+class BaseOAuthProvider(BasePlugin):
+    def __init__(self, long_name: str) -> None:
+        self.__long_name = long_name
+
+    def get_long_name(self) -> str:
+        return self.__long_name
+
+    def is_redirect_from_provider(self, request_query: dict) -> bool:
+        raise NotImplementedError
+
+    def get_authorize_url(self, redirect_url: URL, session: dict) -> str:
+        raise NotImplementedError
+
+    async def get_user_info(
+        self,
+        oauth_session: dict,
+        request_query: dict,
+        redirect_url: URL,
+    ) -> str:
+
+        raise NotImplementedError
+
+    def register_new_session(self) -> dict:
+        raise NotImplementedError
+
+    def is_valid_session(self, oauth_session: dict) -> bool:
+        raise NotImplementedError
+
+
+# =====
+def get_oauth_provider_class(name: str) -> type[BaseOAuthProvider]:
+    return get_plugin_class("oauth", name)  # type: ignore

--- a/kvmd/plugins/oauth/oauth2.py
+++ b/kvmd/plugins/oauth/oauth2.py
@@ -110,7 +110,7 @@ class Plugin(BaseOAuthProvider):  # pylint: disable=too-many-instance-attributes
         for stored_state in self.__states:
             if oauth_session["state"] == stored_state.get_value():
                 if not stored_state.is_valid():
-                    self.__states.pop(oauth_session["state"])
+                    self.__states.remove(stored_state)
                     return False
         return True
 

--- a/kvmd/plugins/oauth/oauth2.py
+++ b/kvmd/plugins/oauth/oauth2.py
@@ -112,7 +112,8 @@ class Plugin(BaseOAuthProvider):  # pylint: disable=too-many-instance-attributes
                 if not stored_state.is_valid():
                     self.__states.remove(stored_state)
                     return False
-        return True
+                return True
+        return False
 
     async def get_user_info(
             self,

--- a/kvmd/plugins/oauth/oauth2.py
+++ b/kvmd/plugins/oauth/oauth2.py
@@ -1,0 +1,194 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                  2024-2024  Markus Beckschulte (SLA/RWTH Aachen)           #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+import secrets
+import time
+from typing import Any
+from typing import Self
+from urllib.parse import urlencode
+
+import aiohttp
+from aiohttp import ClientSession
+from yarl import URL
+
+from ...validators.basic import valid_stripped_string_not_empty
+from ...validators.net import valid_url
+from ...yamlconf import Option
+from . import BaseOAuthProvider, OAuthError
+
+
+class Plugin(BaseOAuthProvider):  # pylint: disable=too-many-instance-attributes
+    def __init__(  # pylint: disable=too-many-arguments
+            self,
+            client_id: str,
+            client_secret: str,
+            access_token_url: str,
+            authorize_url: str,
+            base_url: str,
+            user_info_url: str,
+            _short_name: str,
+            long_name: str,
+            scope: str,
+            username_attribute: str
+    ) -> None:
+        super().__init__(long_name)
+        self.__client_id = client_id
+        self.__client_secret = client_secret
+        self.__access_token_url: URL = URL(access_token_url)
+        self.__authorize_url: URL = URL(authorize_url)
+        self.__base_url: URL = URL(base_url)  # noqa: vulture-ignore
+        self.__user_info_url: URL = URL(user_info_url)
+        self.__scope = scope
+        self.__username_attribute = username_attribute
+        self.__states: list[OAuthState] = []
+
+    @classmethod
+    def get_plugin_options(cls) -> dict:
+        return {
+            "client_id":            Option("", type=valid_stripped_string_not_empty),
+            "client_secret":        Option("", type=valid_stripped_string_not_empty),
+            "access_token_url":     Option("", type=valid_url),
+            "authorize_url":        Option("", type=valid_url),
+            "base_url":             Option("", type=valid_url),
+            "user_info_url":        Option("", type=valid_url),
+            "short_name":           Option("", type=valid_stripped_string_not_empty, unpack_as='_short_name'),
+            "long_name":            Option("", type=valid_stripped_string_not_empty),
+            "scope":                Option("", type=valid_stripped_string_not_empty),
+            "username_attribute":   Option("", type=valid_stripped_string_not_empty),
+        }
+
+    def is_redirect_from_provider(self, request_query: dict) -> bool:
+        return "code" in request_query    # TODO
+
+    def get_authorize_url(self, redirect_url: URL, session: dict) -> str:
+        """
+        Generates the Authorization-Code-Request
+        @param redirect_url: the redirect URL the provider should redirect to after login
+        @param session: the encrypted session
+        @return: the authorization code request url
+        """
+        params: dict[str, str] = {}
+        params.update(
+            {
+                "client_id": self.__client_id,
+                "response_type": "code",
+                "scope": self.__scope,
+                "access_type": "offline",
+                "state": session["state"],
+                "redirect_uri": redirect_url.human_repr(),
+            }
+        )
+        ret = f"{self.__authorize_url}?{urlencode(params)}"
+        return ret
+
+    def is_valid_session(self, oauth_session: dict) -> bool:
+        """
+        Checks if the state provided in the oauth_session is valid.
+        @param oauth_session: the session
+        @return: True: session is valid
+        """
+        if "state" not in oauth_session:
+            return False
+        for stored_state in self.__states:
+            if oauth_session["state"] == stored_state.get_value():
+                if not stored_state.is_valid():
+                    self.__states.pop(oauth_session["state"])
+                    return False
+        return True
+
+    async def get_user_info(
+            self,
+            oauth_session: dict,
+            request_query: dict,
+            redirect_url: URL
+    ) -> str:
+        """
+        Returns the Username provided by the provider. Uses the authorization code to get an access_token.
+        @param oauth_session: the session with state parameter
+        @param request_query: the query as dict containing the authorization code
+        @param redirect_url: the redirect_uri also used in get_authorize_url
+        @return: Username
+        """
+        if not self.is_valid_session(oauth_session):
+            raise OAuthError("unknown or invalid state")
+
+        payload = {
+            "grant_type": "authorization_code",
+            "client_id": self.__client_id,
+            "client_secret": self.__client_secret,
+            "code": request_query["code"],
+            "redirect_uri": str(redirect_url),
+            "state": oauth_session["state"]
+        }
+        headers = {"content-type": "application/x-www-form-urlencoded"}
+        async with ClientSession() as session:
+            try:
+                async with session.post(self.__access_token_url, data=payload, headers=headers) as resp:
+                    token_data = await resp.json()
+                    if "access_token" not in token_data:
+                        raise OAuthError(f"could not get access-token{str(token_data)}")
+                    access_token = token_data.get("access_token")
+            except aiohttp.ClientConnectorError as error:
+                raise OAuthError("could not connect to provider! error message: %s" % str(error))
+
+            headers = {
+                "Cache-Control": "no-cache",
+                "Authorization": f"Bearer {access_token}"
+            }
+            try:
+                async with session.get(self.__user_info_url, headers=headers) as response:
+                    user_info = await response.json()
+                    return user_info.get(self.__username_attribute, "_oauth_user_")
+            except aiohttp.ClientConnectorError as error:
+                raise OAuthError("could not connect to provider! error message: %s" % str(error))
+
+    def register_new_session(self) -> dict:
+        """
+        creates a new session with a new state
+        @return: new session with state
+        """
+        state = OAuthState()
+        self.__states.append(state)
+        return {"state": state.get_value()}
+
+
+class OAuthState:
+    _TTL = 3600.0  # valid for one hour
+
+    def __init__(self) -> None:
+        self.state = secrets.token_urlsafe(16)
+        self.__created = time.time()
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, OAuthState):
+            return self.state == other.state
+        return False
+
+    def __getitem__(self, item: Any) -> Self | None:
+        if item == self.state:
+            return self
+        return None
+
+    def is_valid(self) -> bool:
+        return (self.__created + self._TTL) > time.time()
+
+    def get_value(self) -> str:
+        return self.state

--- a/kvmd/validators/basic.py
+++ b/kvmd/validators/basic.py
@@ -135,3 +135,12 @@ def valid_string_list(
     except Exception:
         raise ValidatorError(f"Failed sub-validator on one of the item of {arg!r}")
     return arg
+
+
+@add_validator_magic
+def valid_dict(arg: Any, name: str="") -> dict[str, Any]:
+    if not name:
+        name = "dict"
+    if not isinstance(arg, dict):
+        raise_error(arg, name)
+    return arg

--- a/kvmd/yamlconf/__init__.py
+++ b/kvmd/yamlconf/__init__.py
@@ -20,6 +20,7 @@
 # ========================================================================== #
 
 
+import dataclasses
 import enum
 import contextlib
 
@@ -35,6 +36,11 @@ class ConfigError(ValueError):
 
 # =====
 class Stub:
+    pass
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class Dynamic:
     pass
 
 

--- a/kvmd/yamlconf/__init__.py
+++ b/kvmd/yamlconf/__init__.py
@@ -136,11 +136,11 @@ def make_config(
 
     config = Section()
 
-    def make_full_path(key: str) -> tuple[str, ...]:
-        return _path + (key,)
+    def make_full_path(*kwargs: str) -> tuple[str, ...]:
+        return _path + kwargs
 
-    def make_full_name(key: str) -> str:
-        return "/".join(make_full_path(key))
+    def make_full_name(*kwargs: str) -> str:
+        return "/".join(make_full_path(*kwargs))
 
     def validate_one(key: str) -> None:
         if isinstance(scheme[key], Option):

--- a/kvmd/yamlconf/__init__.py
+++ b/kvmd/yamlconf/__init__.py
@@ -142,7 +142,7 @@ def make_config(
     def make_full_name(key: str) -> str:
         return "/".join(make_full_path(key))
 
-    for key in scheme:
+    def validate_one(key: str) -> None:
         if isinstance(scheme[key], Option):
             option: Option = scheme[key]
             if key in main and option.default != main[key]:
@@ -173,4 +173,8 @@ def make_config(
         else:
             raise RuntimeError(f"Incorrect scheme definition for key {make_full_name(key)!r}:"
                                f" the value is {type(scheme[key])!r}, not dict() or Option()")
+
+    for key in scheme:
+        validate_one(key)
+
     return config

--- a/kvmd/yamlconf/__init__.py
+++ b/kvmd/yamlconf/__init__.py
@@ -188,6 +188,9 @@ def make_config(
     elif dynamic_schema:
         for key in extra_keys:
             validate_one(key, dynamic_schema[0])
+    # TODO: add an "anything-goes" marker to permit non-validated extra keys,
+    #       then update schema to use this marker everywhere we expect free-form dynamic content
+    #       and finally make unexpected extra keys illegal
     # elif extra_keys:
     #     raise RuntimeError(f"Invalid data at path {make_full_name()!r}: "
     #                        f"unknown keys: {extra_keys}")

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ def main() -> None:
             "kvmd.plugins",
             "kvmd.plugins.auth",
             "kvmd.plugins.flows",
+            "kvmd.plugins.oauth",
             "kvmd.plugins.hid",
             "kvmd.plugins.hid._mcu",
             "kvmd.plugins.hid.otg",

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ def main() -> None:
             "kvmd.keyboard",
             "kvmd.plugins",
             "kvmd.plugins.auth",
+            "kvmd.plugins.flows",
             "kvmd.plugins.hid",
             "kvmd.plugins.hid._mcu",
             "kvmd.plugins.hid.otg",

--- a/testenv/tests/apps/kvmd/test_auth.py
+++ b/testenv/tests/apps/kvmd/test_auth.py
@@ -91,6 +91,8 @@ async def _get_configured_manager(
         force_int_users=(force_int_users or []),
 
         totp_secret_path="",
+
+        flows={},
     )
 
     await manager.sysprep()
@@ -344,6 +346,8 @@ async def test_ok__disabled() -> None:
             force_int_users=[],
 
             totp_secret_path="",
+
+            flows={},
         )
         await manager.sysprep()
 

--- a/web/login/index.html
+++ b/web/login/index.html
@@ -51,6 +51,7 @@
       <div id="login-box">
         <div id="login">
           <table>
+          <tbody>
             <tr>
               <td><img class="svg-gray" id="login-logo" src="../share/svg/logo.svg" alt="&amp;pi;-kvm"></td>
               <td></td>
@@ -104,9 +105,11 @@
             <tr>
               <td></td>
               <td>
-                <button class="key" id="login-button">Login</button>
+                <button class="key login-button" id="login-button">Login</button>
               </td>
             </tr>
+	      </tbody>
+	      <tbody id="oauth-tbody"></tbody>
           </table>
         </div>
       </div>

--- a/web/share/css/login/login.css
+++ b/web/share/css/login/login.css
@@ -46,8 +46,12 @@ img#login-logo {
 	height: 30px;
 }
 
-button#login-button {
-	width: 100%;
+button.login-button {
+    width: 100%;
+}
+
+button.login-button-secondary {
+    width: 100%;
 }
 
 input[type="text"]#user-input,

--- a/web/share/js/login/main.js
+++ b/web/share/js/login/main.js
@@ -115,7 +115,7 @@ function __oauthButton(shortName, longName) {
 }
 
 function __oauthLogin(shortName) {
-	tools.currentOpen(`/api/auth/flow/oauth/login/${shortName}`);
+	tools.currentOpen(`api/auth/flow/oauth/login/${shortName}`);
 }
 
 function __login() {


### PR DESCRIPTION
Preliminary implementation of a pluggable authentication flow architecture, with the OAuth/OAuth2 backend as the first user thereof.

Credits: #156

---

This implementation accepts configuration under the `kvmd.auth.flows.oauth` key, as follows:

```
kvmd:
  auth:
    flows:
      oauth:
        enabled: true
        providers:
          github:
            type: oauth2
            client_id: myclient
            client_secret: mysecret123
            access_token_url: https://github.com/login/oauth/access_token
            authorize_url: https://github.com/login/oauth/authorize
            base_url: https://github.com/
            user_info_url: https://api.github.com/user
            short_name: GitHub
            long_name: GitHub
            scope: openid user
            username_attribute: email
          keycloak:
            type: oauth2
            client_id: client2
            client_secret: str
            access_token_url: https://sso.keycloak.my.tld/realms/master/protocol/openid-connect/token
            authorize_url: https://sso.keycloak.my.tld/realms/master/protocol/openid-connect/auth
            base_url: https://sso.keycloak.my.tld/
            user: https://sso.keycloak.my.tld/realms/master/protocol/openid-connect/
            short_name: Keycloak
            long_name: My Keycloak
            scope: openid profile
            username_attribute: sub
```

UI-wise, each provider corresponds to a separate button on the login page which triggers the corresponding auth flow.

API-wise, the new APIs are located under `/api/auth/flow/oauth/{key}`. The name of a section under `kvmd.auth.flows.oauth.providers` (e.g., `github` or `microsoft`) is an arbitrary URL-safe string, and it is used as the `{key}` in the base URL above.

The callback URL will be `{pi-kvm}/api/auth/flow/oauth/{key}/callback`. You will have to whitelist that URL in the OAuth authorization server in use.