### PR TITLE
udev: look up the USB interface parent node correctly

### DIFF
--- a/configs/os/udev/v0-hdmiusb-rpi2.rules
+++ b/configs/os/udev/v0-hdmiusb-rpi2.rules
@@ -1,4 +1,4 @@
 # https://unix.stackexchange.com/questions/66901/how-to-bind-usb-device-under-a-static-name
 # https://wiki.archlinux.org/index.php/Udev#Setting_static_device_names
-KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", PROGRAM="/usr/bin/kvmd-udev-hdmiusb-check rpi2 %b", ATTR{index}=="0", GROUP="kvmd", SYMLINK+="kvmd-video"
+KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", ATTRS{bInterfaceNumber}=="?*", PROGRAM="/usr/bin/kvmd-udev-hdmiusb-check rpi2 %b", ATTR{index}=="0", GROUP="kvmd", SYMLINK+="kvmd-video"
 KERNEL=="ttyAMA0", SYMLINK+="kvmd-hid"

--- a/configs/os/udev/v0-hdmiusb-rpi3.rules
+++ b/configs/os/udev/v0-hdmiusb-rpi3.rules
@@ -1,4 +1,4 @@
 # https://unix.stackexchange.com/questions/66901/how-to-bind-usb-device-under-a-static-name
 # https://wiki.archlinux.org/index.php/Udev#Setting_static_device_names
-KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", PROGRAM="/usr/bin/kvmd-udev-hdmiusb-check rpi3 %b", ATTR{index}=="0", GROUP="kvmd", SYMLINK+="kvmd-video"
+KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", ATTRS{bInterfaceNumber}=="?*", PROGRAM="/usr/bin/kvmd-udev-hdmiusb-check rpi3 %b", ATTR{index}=="0", GROUP="kvmd", SYMLINK+="kvmd-video"
 KERNEL=="ttyAMA0", SYMLINK+="kvmd-hid"

--- a/configs/os/udev/v1-hdmiusb-rpi2.rules
+++ b/configs/os/udev/v1-hdmiusb-rpi2.rules
@@ -1,3 +1,3 @@
 # https://unix.stackexchange.com/questions/66901/how-to-bind-usb-device-under-a-static-name
 # https://wiki.archlinux.org/index.php/Udev#Setting_static_device_names
-KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", PROGRAM="/usr/bin/kvmd-udev-hdmiusb-check rpi2 %b", ATTR{index}=="0", GROUP="kvmd", SYMLINK+="kvmd-video"
+KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", ATTRS{bInterfaceNumber}=="?*", PROGRAM="/usr/bin/kvmd-udev-hdmiusb-check rpi2 %b", ATTR{index}=="0", GROUP="kvmd", SYMLINK+="kvmd-video"

--- a/configs/os/udev/v1-hdmiusb-rpi3.rules
+++ b/configs/os/udev/v1-hdmiusb-rpi3.rules
@@ -1,3 +1,3 @@
 # https://unix.stackexchange.com/questions/66901/how-to-bind-usb-device-under-a-static-name
 # https://wiki.archlinux.org/index.php/Udev#Setting_static_device_names
-KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", PROGRAM="/usr/bin/kvmd-udev-hdmiusb-check rpi3 %b", ATTR{index}=="0", GROUP="kvmd", SYMLINK+="kvmd-video"
+KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", ATTRS{bInterfaceNumber}=="?*", PROGRAM="/usr/bin/kvmd-udev-hdmiusb-check rpi3 %b", ATTR{index}=="0", GROUP="kvmd", SYMLINK+="kvmd-video"

--- a/configs/os/udev/v2-hdmiusb-rpi4.rules
+++ b/configs/os/udev/v2-hdmiusb-rpi4.rules
@@ -1,6 +1,6 @@
 # https://unix.stackexchange.com/questions/66901/how-to-bind-usb-device-under-a-static-name
 # https://wiki.archlinux.org/index.php/Udev#Setting_static_device_names
-KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", PROGRAM="/usr/bin/kvmd-udev-hdmiusb-check rpi4 %b", ATTR{index}=="0", GROUP="kvmd", SYMLINK+="kvmd-video"
+KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", ATTRS{bInterfaceNumber}=="?*", PROGRAM="/usr/bin/kvmd-udev-hdmiusb-check rpi4 %b", ATTR{index}=="0", GROUP="kvmd", SYMLINK+="kvmd-video"
 KERNEL=="hidg0", GROUP="kvmd", SYMLINK+="kvmd-hid-keyboard"
 KERNEL=="hidg1", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse"
 KERNEL=="hidg2", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse-alt"


### PR DESCRIPTION
The \*-hdmiusb-\* udev rules use `%b` in a script invocation, expecting it
to contain the USB interface node name (e.g. `1-1.4:1.0`). The `%b`
substitution is specified to contain the node name of the last parent
device looked up SUBSYSTEMS/KERNELS/DRIVERS/ATTRS matches, which were
not present.

Use an `ATTRS{bInterfaceNumber}` match to find the closest parent node
corresponding to the USB interface, which is what is expected by the
script.
