### PR TITLE
web: allow server-side defaults for page-close and stream-suspend settings

### DIFF
--- a/web/share/js/kvm/atx.js
+++ b/web/share/js/kvm/atx.js
@@ -39,7 +39,7 @@ export function Atx(__recorder) {
 		$("atx-power-led").title = "Power Led";
 		$("atx-hdd-led").title = "Disk Activity Led";
 
-		tools.storage.bindSimpleSwitch($("atx-ask-switch"), "atx.ask", true);
+		tools.storage.bindSimpleSwitch($("atx-ask-switch"), "atx.ask", tools.config.getBool("kvm--atx-ask", true));
 
 		tools.el.setOnClick($("atx-power-button"), () => __clickAtx("power"));
 		tools.el.setOnClick($("atx-power-button-long"), () => __clickAtx("power_long"));

--- a/web/share/js/kvm/hid.js
+++ b/web/share/js/kvm/hid.js
@@ -75,7 +75,7 @@ export function Hid(__getGeometry, __recorder) {
 			});
 		}
 
-		tools.storage.bindSimpleSwitch($("hid-sysrq-ask-switch"), "hid.sysrq.ask", true);
+		tools.storage.bindSimpleSwitch($("hid-sysrq-ask-switch"), "hid.sysrq.ask", tools.config.getBool("kvm--hid-sysrq-ask", true));
 
 		tools.el.setOnClick($("hid-jiggler-switch"), __clickJigglerSwitch);
 	};

--- a/web/share/js/kvm/keyboard.js
+++ b/web/share/js/kvm/keyboard.js
@@ -50,8 +50,8 @@ export function Keyboard(__recordWsEvent) {
 		window.addEventListener("focusin", __updateOnlineLeds);
 		window.addEventListener("focusout", __updateOnlineLeds);
 
-		tools.storage.bindSimpleSwitch($("hid-keyboard-bad-link-switch"), "hid.keyboard.bad_link", false);
-		tools.storage.bindSimpleSwitch($("hid-keyboard-swap-cc-switch"), "hid.keyboard.swap_cc", false);
+		tools.storage.bindSimpleSwitch($("hid-keyboard-bad-link-switch"), "hid.keyboard.bad_link", tools.config.getBool("kvm--hid-keyboard-bad-link", false));
+		tools.storage.bindSimpleSwitch($("hid-keyboard-swap-cc-switch"), "hid.keyboard.swap_cc", tools.config.getBool("kvm--hid-keyboard-swap-cc", false));
 
 		__el_magic = $("hid-keyboard-magic-selector");
 		let alt = (tools.browser.is_apple ? "Option" : "Alt");

--- a/web/share/js/kvm/main.js
+++ b/web/share/js/kvm/main.js
@@ -45,7 +45,7 @@ export function main() {
 		}
 	}, false);
 
-	tools.storage.bindSimpleSwitch($("page-close-ask-switch"), "page.close.ask", true, function(value) {
+	tools.storage.bindSimpleSwitch($("page-close-ask-switch"), "page.close.ask", tools.config.getBool("kvm--page-close-ask", true), function(value) {
 		if (value) {
 			window.onbeforeunload = function(ev) {
 				let text = "Are you sure you want to close PiKVM session?";

--- a/web/share/js/kvm/mouse.js
+++ b/web/share/js/kvm/mouse.js
@@ -85,12 +85,12 @@ export function Mouse(__getGeometry, __recordWsEvent) {
 		$("stream-box").addEventListener("touchmove", __streamTouchMoveHandler);
 		$("stream-box").addEventListener("touchend", __streamTouchEndHandler);
 
-		tools.storage.bindSimpleSwitch($("hid-mouse-squash-switch"), "hid.mouse.squash", true);
-		tools.storage.bindSimpleSwitch($("hid-mouse-reverse-scrolling-y-switch"), "hid.mouse.reverse_scrolling", false);
-		tools.storage.bindSimpleSwitch($("hid-mouse-reverse-scrolling-x-switch"), "hid.mouse.reverse_panning", false);
+		tools.storage.bindSimpleSwitch($("hid-mouse-squash-switch"), "hid.mouse.squash", tools.config.getBool("kvm--hid-mouse-squash", true));
+		tools.storage.bindSimpleSwitch($("hid-mouse-reverse-scrolling-y-switch"), "hid.mouse.reverse_scrolling", tools.config.getBool("kvm--hid-mouse-reverse-scrolling", false));
+		tools.storage.bindSimpleSwitch($("hid-mouse-reverse-scrolling-x-switch"), "hid.mouse.reverse_panning", tools.config.getBool("kvm--hid-mouse-reverse-panning", false));
 		let cumulative_scrolling = !(tools.browser.is_firefox && !tools.browser.is_mac);
-		tools.storage.bindSimpleSwitch($("hid-mouse-cumulative-scrolling-switch"), "hid.mouse.cumulative_scrolling", cumulative_scrolling);
-		tools.storage.bindSimpleSwitch($("hid-mouse-dot-switch"), "hid.mouse.dot", true, __updateOnlineLeds);
+		tools.storage.bindSimpleSwitch($("hid-mouse-cumulative-scrolling-switch"), "hid.mouse.cumulative_scrolling", tools.config.getBool("kvm--hid-mouse-cumulative-scrolling", cumulative_scrolling));
+		tools.storage.bindSimpleSwitch($("hid-mouse-dot-switch"), "hid.mouse.dot", tools.config.getBool("kvm--hid-mouse-dot", true), __updateOnlineLeds);
 
 		__updateOnlineLeds();
 	};

--- a/web/share/js/kvm/paste.js
+++ b/web/share/js/kvm/paste.js
@@ -39,9 +39,9 @@ export function Paste(__recorder) {
 			}
 		});
 
-		tools.storage.bindSimpleSwitch($("hid-pak-ask-switch"), "hid.pak.ask", true);
+		tools.storage.bindSimpleSwitch($("hid-pak-ask-switch"), "hid.pak.ask", tools.config.getBool("kvm--hid-pak-ask", true));
 
-		tools.storage.bindSimpleSwitch($("hid-pak-secure-switch"), "hid.pak.secure", false, function(value) {
+		tools.storage.bindSimpleSwitch($("hid-pak-secure-switch"), "hid.pak.secure", tools.config.getBool("kvm--hid-pak-secure", false), function(value) {
 			$("hid-pak-text").style.setProperty("-webkit-text-security", (value ? "disc" : "none"));
 		});
 

--- a/web/share/js/kvm/stream.js
+++ b/web/share/js/kvm/stream.js
@@ -73,7 +73,7 @@ export function Streamer() {
 
 		// Not getInt() because of radio is a string container.
 		// Also don't reset Streamer at class init.
-		tools.radio.clickValue("stream-orient-radio", tools.storage.get("stream.orient", 0));
+		tools.radio.clickValue("stream-orient-radio", tools.storage.get("stream.orient", tools.config.get("kvm--stream-orient", 0)));
 		tools.radio.setOnClick("stream-orient-radio", function() {
 			if (["janus", "media"].includes(__streamer.getMode())) {
 				let orient = parseInt(tools.radio.getValue("stream-orient-radio"));
@@ -98,7 +98,7 @@ export function Streamer() {
 			tools.el.setEnabled($("stream-cam-switch"), !!value);
 		});
 
-		tools.storage.bindSimpleSwitch($("stream-mic-switch"), "stream.mic", false, function(allow_mic) {
+		tools.storage.bindSimpleSwitch($("stream-mic-switch"), "stream.mic", tools.config.getBool("kvm--stream-mic", false), function(allow_mic) {
 			if (__streamer.getMode() === "janus") {
 				if (__streamer.isMicAllowed() !== allow_mic) {
 					__resetStream();
@@ -106,7 +106,7 @@ export function Streamer() {
 			}
 		});
 
-		tools.storage.bindSimpleSwitch($("stream-cam-switch"), "stream.cam", false, function(allow_cam) {
+		tools.storage.bindSimpleSwitch($("stream-cam-switch"), "stream.cam", tools.config.getBool("kvm--stream-cam", false), function(allow_cam) {
 			if (__streamer.getMode() === "janus") {
 				if (__streamer.isCamAllowed() !== allow_cam) {
 					__resetStream();
@@ -117,7 +117,7 @@ export function Streamer() {
 		tools.el.setOnClick($("stream-screenshot-button"), __clickScreenshotButton);
 		tools.el.setOnClick($("stream-reset-button"), __clickResetButton);
 
-		tools.storage.bindSimpleSwitch($("stream-suspend-switch"), "stream.suspend", false, __visibilityHook);
+		tools.storage.bindSimpleSwitch($("stream-suspend-switch"), "stream.suspend", tools.config.getBool("kvm--stream-suspend", false), __visibilityHook);
 
 		$("stream-window").show_hook = __visibilityHook;
 		$("stream-window").close_hook = __visibilityHook;
@@ -253,7 +253,7 @@ export function Streamer() {
 				tools.feature.setEnabled($("stream-cam"), false);
 			}
 
-			let mode = tools.storage.get("stream.mode", "janus");
+			let mode = tools.storage.get("stream.mode", tools.config.get("kvm--stream-mode", "janus"));
 			if (mode === "janus" && !has_janus) {
 				mode = "media";
 			}

--- a/web/share/js/kvm/switch.js
+++ b/web/share/js/kvm/switch.js
@@ -45,8 +45,8 @@ export function Switch() {
 		tools.el.setOnClick($("switch-edid-remove-button"), __clickRemoveEdidButton);
 		tools.el.setOnClick($("switch-edid-copy-data-button"), __clickCopyEdidDataButton);
 
-		tools.storage.bindSimpleSwitch($("switch-atx-ask-switch"), "switch.atx.ask", true);
-		tools.storage.bindSimpleSwitch($("switch-msd-ask-switch"), "switch.msd.ask", true);
+		tools.storage.bindSimpleSwitch($("switch-atx-ask-switch"), "switch.atx.ask", tools.config.getBool("kvm--switch-atx-ask", true));
+		tools.storage.bindSimpleSwitch($("switch-msd-ask-switch"), "switch.msd.ask", tools.config.getBool("kvm--switch-msd-ask", true));
 
 		for (let role of ["inactive", "active", "flashing", "beacon", "bootloader"]) {
 			let el_brightness = $(`switch-color-${role}-brightness-slider`);


### PR DESCRIPTION
## Summary

The Web UI has ~18 client-side settings with defaults hardcoded in JavaScript. Only one of them (`Expand for the entire tab by default`) uses the existing `tools.config.getBool()` mechanism to allow server-side configuration via CSS custom properties in `/etc/kvmd/web.css`.

This PR extends that same pattern to **all** remaining settings, so admins can configure defaults for every UI toggle server-side.

## What changed

Every `tools.storage.bindSimpleSwitch()` call with a hardcoded default now reads from `tools.config.getBool()` (or `tools.config.get()` for non-boolean values) first, falling back to the original default. No behavior changes when no CSS properties are set.

**Files changed:**
- `web/share/js/kvm/main.js` — page close confirmation
- `web/share/js/kvm/stream.js` — stream suspend, mic, cam, mode, orientation
- `web/share/js/kvm/atx.js` — ATX confirmation dialog
- `web/share/js/kvm/switch.js` — switch ATX/MSD confirmations
- `web/share/js/kvm/hid.js` — SysRq confirmation
- `web/share/js/kvm/keyboard.js` — bad link, swap Ctrl/CapsLock
- `web/share/js/kvm/mouse.js` — squash, reverse scroll X/Y, cumulative scroll, dot cursor
- `web/share/js/kvm/paste.js` — paste confirmation, secure mode

## Example usage

Admins can now set defaults in `/etc/kvmd/web.css`:

```css
:root {
    /* Interface settings */
    --config-ui--kvm--page-close-ask: 0;
    --config-ui--kvm--full-tab-stream: 1;      /* already worked before */
    --config-ui--kvm--stream-suspend: 1;

    /* Stream settings */
    --config-ui--kvm--stream-mode: mjpeg;       /* janus, media, or mjpeg */
    --config-ui--kvm--stream-orient: 0;         /* 0, 90, 180, 270 */
    --config-ui--kvm--stream-mic: 0;
    --config-ui--kvm--stream-cam: 0;

    /* Confirmation dialogs */
    --config-ui--kvm--atx-ask: 0;
    --config-ui--kvm--switch-atx-ask: 0;
    --config-ui--kvm--switch-msd-ask: 0;
    --config-ui--kvm--hid-sysrq-ask: 0;
    --config-ui--kvm--hid-pak-ask: 0;
    --config-ui--kvm--hid-pak-secure: 1;

    /* Keyboard */
    --config-ui--kvm--hid-keyboard-bad-link: 0;
    --config-ui--kvm--hid-keyboard-swap-cc: 0;

    /* Mouse */
    --config-ui--kvm--hid-mouse-squash: 1;
    --config-ui--kvm--hid-mouse-reverse-scrolling: 0;
    --config-ui--kvm--hid-mouse-reverse-panning: 0;
    --config-ui--kvm--hid-mouse-cumulative-scrolling: 1;
    --config-ui--kvm--hid-mouse-dot: 1;
}
```

These set the **initial default** for new users or cleared browsers. Users can still override via the UI, and their preference is saved in localStorage as before.

## Notes

- Zero behavior change when no CSS custom properties are set — all original hardcoded values are preserved as fallbacks
- The `tools.config.getBool()` / `tools.config.get()` infrastructure and the CSS injection pipeline (`/etc/kvmd/web.css` → nginx `user.css` alias → `:root` properties) already exist
- This is particularly useful for kiosk deployments or multi-user setups where admins want consistent defaults