### PR TITLE
feat: add support for vendor_id, product_id and product name for audio devices

### DIFF
--- a/kvmd/apps/_scheme.py
+++ b/kvmd/apps/_scheme.py
@@ -572,6 +572,9 @@ def make_config_scheme() -> dict:
                 "audio": {
                     "enabled":  Option(False, type=valid_bool),
                     "start":    Option(True,  type=valid_bool),
+                    "vendor_id":  Option(None, type=valid_otg_id, if_none=None),
+                    "product_id": Option(None, type=valid_otg_id, if_none=None),
+                    "product":    Option("",   type=valid_stripped_string, if_empty=""),
                 },
 
                 "drives": {

--- a/kvmd/apps/otg/__init__.py
+++ b/kvmd/apps/otg/__init__.py
@@ -113,7 +113,14 @@ class _GadgetConfig:
         self.__msd_instance = 0
         _mkdir(meta_path)
 
-    def add_audio_mic(self, starter: list[str], start: bool) -> None:
+    def add_audio_mic(
+        self,
+        starter: list[str],
+        start: bool,
+        vendor_id: (int | None)=None,
+        product_id: (int | None)=None,
+        product: str="",
+    ) -> None:
         eps = 2
         func = "uac2.usb0"
         func_path = self.__create_function(func)
@@ -121,6 +128,12 @@ class _GadgetConfig:
         _write(join(func_path, "p_chmask"), 0b11)
         _write(join(func_path, "p_srate"), 48000)
         _write(join(func_path, "p_ssize"), 2)
+        if vendor_id is not None:
+            _write(join(func_path, "b_vendor_id"), f"0x{vendor_id:04X}", optional=True)
+        if product_id is not None:
+            _write(join(func_path, "b_product_id"), f"0x{product_id:04X}", optional=True)
+        if product:
+            _write(join(func_path, "function_name"), product, optional=True)
         if start:
             self.__start_function(func, eps)
         self.__create_meta(func, "Microphone", eps, starter)
@@ -353,7 +366,13 @@ def _cmd_start(config: Section) -> None:  # pylint: disable=too-many-statements,
 
     if cod.audio.enabled:
         logger.info("===== Microphone =====")
-        gc.add_audio_mic(["audio"], cod.audio.start)
+        gc.add_audio_mic(
+            ["audio"],
+            cod.audio.start,
+            vendor_id=cod.audio.vendor_id,
+            product_id=cod.audio.product_id,
+            product=cod.audio.product,
+        )
 
     logger.info("===== Preparing complete =====")
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Currently, I can't configure the hardware ids for the audio devices.

**Describe the solution you'd like**
I would like the option in yaml to set the parameters accordingly to simulate real devices (and prevent Microsoft Entra Device endpoint problems).
**Describe alternatives you've considered**
Not using the audio

**Additional context**

