### PR TITLE
Add optional cipher suite parameter to IPMI GPIO pseudo-driver

### DIFF
--- a/kvmd/plugins/ugpio/ipmi.py
+++ b/kvmd/plugins/ugpio/ipmi.py
@@ -86,6 +86,7 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
         return {
             "host":   Option("",  type=valid_ip_or_host),
             "port":   Option(623, type=valid_port),
+            "cipher": Option(17,  type=valid_number.mk(min=0, max=19)),
             "user":   Option(""),
             "passwd": Option(""),
 
@@ -93,6 +94,7 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
             "cmd": Option([
                 "/usr/bin/ipmitool",
                 "-I", "lanplus",
+                "-C", "{cipher}",
                 "-U", "{user}", "-E",
                 "-H", "{host}", "-p", "{port}",
                 "power", "{action}",

--- a/kvmd/plugins/ugpio/ipmi.py
+++ b/kvmd/plugins/ugpio/ipmi.py
@@ -38,6 +38,7 @@ from ...yamlconf import Option
 
 from ...validators import check_string_in_list
 from ...validators.basic import valid_float_f01
+from ...validators.basic import valid_number
 from ...validators.net import valid_ip_or_host
 from ...validators.net import valid_port
 from ...validators.os import valid_command
@@ -70,6 +71,7 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
 
         self.__host:   Final[str] = c.host
         self.__port:   Final[int] = c.port
+        self.__cipher: Final[int] = c.cipher
         self.__user:   Final[str] = c.user
         self.__passwd: Final[str] = c.passwd
 
@@ -179,6 +181,7 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
                 part.format(
                     host=self.__host,
                     port=self.__port,
+                    cipher=self.__cipher,
                     user=self.__user,
                     passwd=self.__passwd,
                     action=action,


### PR DESCRIPTION
## Summary

With changes to the IPMI specification over the years, the default cipher suite utilised by the `ipmitool` library may not work with older servers that support earlier versions of the IPMI spec.

This PR extends the existing IPMI GPIO pseudo-driver to allow defining alternative cipher suites for connecting to a server. 

## What changed

Introduction of a new optional cipher suite ID parameter called `cipher` for the IPMI GPIO pseudo-driver for defining different cipher suites.

The cipher suite IDs are defined in Table 22-10 of the [IPMI v2 Specification](https://www.intel.la/content/dam/www/public/us/en/documents/specification-updates/ipmi-intelligent-platform-mgt-interface-spec-2nd-gen-v2-0-spec-update.pdf), ranging from ID 0 through 19, these IDs define the combination of algorithms used for authentication, integrity and confidentiality, when making the connection to a server.

Currently the `ipmitool` library defaults to using the cipher suite ID 17, hence this is the defined default in this PR. 

**Files changed:**
- `kvmd/plugins/ugpio/ipmi.py` — Psuedo-driver for IPMI

## Example usage

When configuring the GPIO config in PiKVM `override.yaml` file, the IPMI pseudo-driver can now be defined with the optional cipher suite.

```yaml
kvmd:
...
    gpio:
        drivers:
            my_server:
                type: ipmi
                host: myserver.local
                user: admin
                passwd: admin
                cipher: 3
...
```

## Notes

- This new parameter is optional, and is only required when interfacing with an IPMI interface that doesn't support the security ciphers.