### PR TITLE
PKGBUILD: fix packaging, follow PEP 517

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -223,7 +223,7 @@ for _variant in "${_variants[@]}"; do
 		backup=()
 
 		pkgdesc=\"PiKVM platform configs - $_platform for $_board\"
-		depends=(kvmd=$pkgver-$pkgrel \"linux-rpi-pikvm>=6.12.56-6\" \"raspberrypi-bootloader-pikvm>=20251031-1\")
+		depends=(kvmd=\"${epoch:+$epoch:}$pkgver-$pkgrel\" \"linux-rpi-pikvm>=6.12.56-6\" \"raspberrypi-bootloader-pikvm>=20251031-1\")
 
 		if [[ $_base == v0 ]]; then
 			depends=(\"\${depends[@]}\" platformio-core avrdude make patch)

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -148,7 +148,7 @@ makedepends=(
 	python-setuptools
 	python-pip
 )
-source=("$url/archive/v$pkgver.tar.gz")
+source=("kvmd-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
 md5sums=(SKIP)
 backup=(
 	etc/kvmd/{override,meta}.yaml
@@ -216,7 +216,7 @@ for _variant in "${_variants[@]}"; do
 	_base=${_platform%-*}
 	_video=${_platform#*-}
 	eval "package_kvmd-platform-$_platform-$_board() {
-		cd \"kvmd-\$pkgver\"
+		cd \"kvmd-$pkgver\"
 
 		install=platform.install
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -145,8 +145,10 @@ conflicts=(
 	python-bcrypt
 )
 makedepends=(
+	python-build
+	python-installer
+	python-wheel
 	python-setuptools
-	python-pip
 )
 source=("kvmd-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
 md5sums=(SKIP)
@@ -160,12 +162,16 @@ backup=(
 	etc/kvmd/web.css
 )
 
+build() {
+	cd "$srcdir/kvmd-$pkgver"
+	python -m build --wheel --no-isolation
+}
 
 package_kvmd() {
 	install=kvmd.install
 
 	cd "$srcdir/kvmd-$pkgver"
-	pip install --root="$pkgdir" --no-deps .
+	python -m installer --destdir="$pkgdir" dist/*.whl
 
 	install -Dm755 -t "$pkgdir/usr/bin" scripts/kvmd-{bootconfig,gencert,certbot}
 

--- a/setup.py
+++ b/setup.py
@@ -21,39 +21,11 @@
 # ========================================================================== #
 
 
-import textwrap
-
-import setuptools.command.easy_install
 from setuptools import setup
 
 
 # =====
-class _Template(str):
-    def __init__(self, text: str) -> None:
-        self.__text = textwrap.dedent(text).strip()
-
-    def __mod__(self, kv: dict) -> str:
-        kv = {"module_name": kv["ep"].module_name, **kv}
-        return (self.__text % (kv))
-
-
-class _ScriptWriter(setuptools.command.easy_install.ScriptWriter):
-    template = _Template("""
-        # EASY-INSTALL-ENTRY-SCRIPT: %(spec)r,%(group)r,%(name)r
-
-        __requires__ = %(spec)r
-
-        from %(module_name)s import main
-
-        if __name__ == '__main__':
-            main()
-    """)
-
-
-# =====
 def main() -> None:
-    setuptools.command.easy_install.ScriptWriter = _ScriptWriter
-
     setup(
         name="kvmd",
         version="4.168",


### PR DESCRIPTION
- cosmetics (do not needlessly escape `$pkgver`, use package name as part of source tarball name)
- include `$epoch` in versioned depends when set (otherwise, subpackages of version `1:123-456` would end up depending on kvmd of version `123-456`)
- drop obsolete and defunct console_script template override (not functional since >1 year ago due to setuptools changes and obsoletion of non-wheel installation flow, and not worth coming up with a new hack due to new templates having much lower overhead)
- use proper PEP 517 packaging process (`python -m build` and `python -m installer`) instead of abusing `pip install --root=... --no-deps`)