### PR TITLE
testenv: hacks around vulture

### DIFF
--- a/testenv/tox.ini
+++ b/testenv/tox.ini
@@ -36,7 +36,7 @@ deps =
 
 [testenv:vulture]
 allowlist_externals = bash
-commands = bash -c 'vulture --ignore-names=_format_P,Plugin --ignore-decorators=@exposed_http,@exposed_ws,@pytest.fixture kvmd testenv/tests *.py testenv/linters/vulture-wl.py'
+commands = bash -c 'testenv/wrappers/wrap_vulture.py --ignore-names=_format_P,Plugin --ignore-decorators=@exposed_http,@exposed_ws,@pytest.fixture kvmd testenv/tests *.py testenv/linters/vulture-wl.py'
 deps =
 	vulture
 	-rrequirements.txt

--- a/testenv/wrappers/wrap_vulture.py
+++ b/testenv/wrappers/wrap_vulture.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import sys
+from collections import defaultdict
+
+import vulture.core
+import vulture.noqa
+from vulture.noqa import NOQA_REGEXP, _parse_error_codes
+
+NOQA_CODE_MAP = {
+    "vulture-unused": ["V101", "V102", "V103", "V104", "V105", "V106", "V107"]
+}
+
+def parse_noqa_custom(code):
+    noqa_lines = defaultdict(set)
+    for lineno, line in enumerate(code, start=1):
+        match = NOQA_REGEXP.search(line)
+        if match:
+            for error_code in _parse_error_codes(match):
+                error_code = NOQA_CODE_MAP.get(error_code, error_code)
+                if not isinstance(error_code, list):
+                    error_code = [error_code]
+                for code in error_code:
+                    noqa_lines[code].add(lineno)
+    return noqa_lines
+
+if __name__ == "__main__":
+    vulture.noqa.NOQA_CODE_MAP.update(NOQA_CODE_MAP)
+    vulture.noqa.parse_noqa_custom = parse_noqa_custom
+    sys.argv[0] = "vulture"
+    exit(vulture.core.main())


### PR DESCRIPTION
- **testenv: wrappers: add wrap_vulture.py to implement a saner ignore mechanic**
- **testenv: tox.ini: use wrap_vulture.py**
