### PR TITLE
Fix Python type hint syntax error in proto.py

### DIFF
--- a/kvmd/apps/kvmd/switch/proto.py
+++ b/kvmd/apps/kvmd/switch/proto.py
@@ -19,6 +19,7 @@
 #                                                                            #
 # ========================================================================== #
 
+from __future__ import annotations
 
 import struct
 import dataclasses


### PR DESCRIPTION
## Problem
The application fails to start with a `SyntaxError` when Python tries to parse type hints using the `|` union operator with string literals in `kvmd/apps/kvmd/switch/proto.py` at line 133.

```
File "kvmd/apps/kvmd/switch/proto.py", line 133, in UnitState
  def compare_edid(self, ch: int, edid: ("Edid" | None)) -> bool:
                                        ~~~~~~~^~~~~~
SyntaxError: invalid syntax
```

## Root Cause
The file was missing `from __future__ import annotations`, which enables deferred evaluation of type hints. Without this import, Python attempts to evaluate `"Edid" | None` at runtime as actual code (using the bitwise OR operator), which is invalid syntax for a string and `None` type.

## Solution
Added `from __future__ import annotations` as the first import in the file (after the license header). This:
- Enables PEP 563 (deferred evaluation of annotations)
- Allows the modern `X | Y` union syntax (PEP 604) to work correctly
- Enables forward references without requiring string quotes

## Changes
- `kvmd/apps/kvmd/switch/proto.py`: Added `from __future__ import annotations` import

## Testing
- Verified the syntax error is resolved and the module can now be imported successfully


Co-authored with claude haiku 4.5