### PR TITLE
Add Gamer Mode: low-latency WebRTC streaming via webrtcbin

### DIFF
--- a/contrib/gamer-mode/gamer_streamer.py
+++ b/contrib/gamer-mode/gamer_streamer.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""
+PiKVM Gamer Mode Streamer - Low-latency WebRTC video via GStreamer webrtcbin.
+
+Replaces the Janus→ustreamer path with a direct GStreamer pipeline:
+  v4l2src → v4l2h264enc → rtph264pay → webrtcbin → browser
+
+WebRTC signaling is handled via a simple aiohttp WebSocket server.
+The browser connects, exchanges SDP offer/answer and ICE candidates,
+and receives the H.264 stream directly — no Janus middleman.
+
+Usage:
+  python3 gamer_streamer.py [--device /dev/video0] [--port 8765] [--fps 60]
+
+Dependencies:
+  - GStreamer 1.x with gst-plugins-bad (for webrtcbin)
+  - PyGObject (gi.repository.Gst, GstSdp, GstWebRTC)
+  - aiohttp
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+
+import gi
+gi.require_version("Gst", "1.0")
+gi.require_version("GstSdp", "1.0")
+gi.require_version("GstWebRTC", "1.0")
+from gi.repository import Gst, GstSdp, GstWebRTC, GLib
+
+import aiohttp
+from aiohttp import web
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("gamer")
+
+Gst.init(None)
+
+
+class GamerPipeline:
+    def __init__(self, device: str, fps: int, bitrate: int):
+        self._device = device
+        self._fps = fps
+        self._bitrate = bitrate
+        self._pipe = None
+        self._webrtcbin = None
+        self._ws = None
+        self._loop = None
+
+    def build(self, loop: asyncio.AbstractEventLoop):
+        self._loop = loop
+
+        encoder = self._detect_encoder()
+        pipe_str = (
+            f"v4l2src device={self._device} "
+            f"! video/x-raw,framerate={self._fps}/1 "
+            f"! videoconvert "
+            f"! {encoder} "
+            f"! video/x-h264,profile=constrained-baseline "
+            f"! rtph264pay config-interval=-1 pt=96 "
+            f"! application/x-rtp,media=video,encoding-name=H264,payload=96 "
+            f"! webrtcbin name=webrtc bundle-policy=max-bundle "
+            f"  stun-server=stun://stun.l.google.com:19302"
+        )
+        logger.info("Pipeline: %s", pipe_str)
+        self._pipe = Gst.parse_launch(pipe_str)
+        self._webrtcbin = self._pipe.get_by_name("webrtc")
+
+        self._webrtcbin.connect("on-negotiation-needed", self._on_negotiation_needed)
+        self._webrtcbin.connect("on-ice-candidate", self._on_ice_candidate)
+        self._webrtcbin.connect("pad-added", self._on_pad_added)
+
+        # Disable jitter buffer for minimum latency
+        self._webrtcbin.set_property("latency", 0)
+
+    def _detect_encoder(self) -> str:
+        hw = Gst.ElementFactory.find("v4l2h264enc")
+        if hw:
+            logger.info("Using v4l2h264enc (Pi hardware encoder)")
+            return (
+                f"v4l2h264enc extra-controls=\"encode,h264_profile=1,h264_level=11,"
+                f"video_bitrate={self._bitrate * 1000}\" "
+                f"! video/x-h264,level=(string)4"
+            )
+        logger.info("v4l2h264enc not available, falling back to x264enc (software)")
+        return (
+            f"x264enc tune=zerolatency bitrate={self._bitrate} "
+            f"speed-preset=ultrafast key-int-max={self._fps}"
+        )
+
+    def start(self):
+        self._pipe.set_state(Gst.State.PLAYING)
+        logger.info("Pipeline started")
+
+    def stop(self):
+        if self._pipe:
+            self._pipe.set_state(Gst.State.NULL)
+            logger.info("Pipeline stopped")
+
+    def set_ws(self, ws):
+        self._ws = ws
+
+    def _on_negotiation_needed(self, webrtcbin):
+        logger.info("Negotiation needed — creating offer")
+        promise = Gst.Promise.new_with_change_func(self._on_offer_created)
+        webrtcbin.emit("create-offer", None, promise)
+
+    def _on_offer_created(self, promise):
+        promise.wait()
+        reply = promise.get_reply()
+        offer = reply.get_value("offer")
+        self._webrtcbin.emit("set-local-description", offer, None)
+        sdp_text = offer.sdp.as_text()
+        logger.info("SDP offer created (%d chars)", len(sdp_text))
+        if self._ws and self._loop:
+            asyncio.run_coroutine_threadsafe(
+                self._ws.send_json({"type": "offer", "sdp": sdp_text}),
+                self._loop,
+            )
+
+    def _on_ice_candidate(self, webrtcbin, mline_index, candidate):
+        if self._ws and self._loop:
+            asyncio.run_coroutine_threadsafe(
+                self._ws.send_json({
+                    "type": "ice",
+                    "candidate": candidate,
+                    "sdpMLineIndex": mline_index,
+                }),
+                self._loop,
+            )
+
+    def _on_pad_added(self, webrtcbin, pad):
+        logger.info("Pad added: %s", pad.get_name())
+
+    async def handle_message(self, msg: dict):
+        if msg["type"] == "answer":
+            sdp = msg["sdp"]
+            logger.info("Received SDP answer (%d chars)", len(sdp))
+            res, sdpmsg = GstSdp.SDPMessage.new()
+            GstSdp.sdp_message_parse_buffer(bytes(sdp, "utf-8"), sdpmsg)
+            answer = GstWebRTC.WebRTCSessionDescription.new(
+                GstWebRTC.WebRTCSDPType.ANSWER, sdpmsg
+            )
+            self._webrtcbin.emit("set-remote-description", answer, None)
+
+        elif msg["type"] == "ice":
+            candidate = msg["candidate"]
+            sdp_mline_index = msg["sdpMLineIndex"]
+            self._webrtcbin.emit("add-ice-candidate", sdp_mline_index, candidate)
+
+
+class GamerServer:
+    def __init__(self, device: str, fps: int, bitrate: int, port: int):
+        self._device = device
+        self._fps = fps
+        self._bitrate = bitrate
+        self._port = port
+        self._pipeline = None
+
+    async def _ws_handler(self, request):
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        logger.info("WebSocket client connected")
+
+        loop = asyncio.get_event_loop()
+
+        # Build a fresh pipeline for each connection (1:1 streaming)
+        if self._pipeline:
+            self._pipeline.stop()
+
+        self._pipeline = GamerPipeline(self._device, self._fps, self._bitrate)
+        self._pipeline.build(loop)
+        self._pipeline.set_ws(ws)
+        self._pipeline.start()
+
+        try:
+            async for msg in ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    data = json.loads(msg.data)
+                    await self._pipeline.handle_message(data)
+                elif msg.type == aiohttp.WSMsgType.ERROR:
+                    logger.error("WS error: %s", ws.exception())
+                    break
+        finally:
+            logger.info("WebSocket client disconnected")
+            self._pipeline.stop()
+            self._pipeline = None
+
+        return ws
+
+    async def _index_handler(self, request):
+        return web.Response(text=_INDEX_HTML, content_type="text/html")
+
+    def run(self):
+        app = web.Application()
+        app.router.add_get("/", self._index_handler)
+        app.router.add_get("/ws", self._ws_handler)
+        logger.info("Gamer Mode streamer on port %d (device=%s, fps=%d, bitrate=%d)",
+                     self._port, self._device, self._fps, self._bitrate)
+        web.run_app(app, port=self._port)
+
+
+_INDEX_HTML = """<!DOCTYPE html>
+<html>
+<head>
+<title>PiKVM Gamer Mode</title>
+<style>
+body { margin: 0; background: #000; display: flex; justify-content: center; align-items: center; height: 100vh; }
+video { max-width: 100vw; max-height: 100vh; }
+#status { position: fixed; top: 10px; left: 10px; color: #0f0; font-family: monospace; font-size: 14px; }
+</style>
+</head>
+<body>
+<div id="status">Connecting...</div>
+<video id="video" autoplay playsinline muted></video>
+<script>
+const video = document.getElementById('video');
+const status = document.getElementById('status');
+let pc = null;
+
+function connect() {
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const ws = new WebSocket(proto + '//' + location.host + '/ws');
+
+    ws.onopen = () => { status.textContent = 'WebSocket connected, waiting for offer...'; };
+
+    ws.onmessage = async (ev) => {
+        const msg = JSON.parse(ev.data);
+
+        if (msg.type === 'offer') {
+            status.textContent = 'Got offer, creating answer...';
+            pc = new RTCPeerConnection({
+                iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
+            });
+
+            pc.ontrack = (event) => {
+                status.textContent = 'Stream active!';
+                video.srcObject = event.streams[0];
+            };
+
+            pc.onicecandidate = (event) => {
+                if (event.candidate) {
+                    ws.send(JSON.stringify({
+                        type: 'ice',
+                        candidate: event.candidate.candidate,
+                        sdpMLineIndex: event.candidate.sdpMLineIndex
+                    }));
+                }
+            };
+
+            pc.oniceconnectionstatechange = () => {
+                status.textContent = 'ICE: ' + pc.iceConnectionState;
+            };
+
+            // Modify SDP to disable jitter buffer (low latency)
+            let sdp = msg.sdp;
+
+            await pc.setRemoteDescription({ type: 'offer', sdp: sdp });
+            const answer = await pc.createAnswer();
+            await pc.setLocalDescription(answer);
+            ws.send(JSON.stringify({ type: 'answer', sdp: answer.sdp }));
+            status.textContent = 'Answer sent, waiting for stream...';
+        }
+
+        else if (msg.type === 'ice') {
+            if (pc && msg.candidate) {
+                await pc.addIceCandidate({
+                    candidate: msg.candidate,
+                    sdpMLineIndex: msg.sdpMLineIndex
+                });
+            }
+        }
+    };
+
+    ws.onclose = () => {
+        status.textContent = 'Disconnected. Reconnecting in 2s...';
+        setTimeout(connect, 2000);
+    };
+
+    ws.onerror = () => { ws.close(); };
+}
+
+connect();
+</script>
+</body>
+</html>
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PiKVM Gamer Mode Streamer")
+    parser.add_argument("--device", default="/dev/video0", help="V4L2 device")
+    parser.add_argument("--port", type=int, default=8765, help="WebSocket port")
+    parser.add_argument("--fps", type=int, default=60, help="Target framerate")
+    parser.add_argument("--bitrate", type=int, default=5000, help="H.264 bitrate (kbps)")
+    args = parser.parse_args()
+
+    server = GamerServer(args.device, args.fps, args.bitrate, args.port)
+    server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/gamer-mode/gamer_streamer.py
+++ b/contrib/gamer-mode/gamer_streamer.py
@@ -2,20 +2,19 @@
 """
 PiKVM Gamer Mode Streamer - Low-latency WebRTC video via GStreamer webrtcbin.
 
-Replaces the Janus→ustreamer path with a direct GStreamer pipeline:
-  v4l2src → v4l2h264enc → rtph264pay → webrtcbin → browser
+Replaces the Janus->ustreamer path with a direct GStreamer pipeline:
+  v4l2src -> v4l2h264enc -> rtph264pay -> webrtcbin -> browser
 
-WebRTC signaling is handled via a simple aiohttp WebSocket server.
-The browser connects, exchanges SDP offer/answer and ICE candidates,
-and receives the H.264 stream directly — no Janus middleman.
-
-Usage:
-  python3 gamer_streamer.py [--device /dev/video0] [--port 8765] [--fps 60]
+Two signaling transports:
+  --stdio (default): JSON lines on stdin/stdout. kvmd parents this process
+    and bridges to the browser via its existing /ws WebSocket.
+  --port N (legacy spike mode): standalone aiohttp WS server + embedded
+    HTML client. Useful for development without kvmd.
 
 Dependencies:
   - GStreamer 1.x with gst-plugins-bad (for webrtcbin)
   - PyGObject (gi.repository.Gst, GstSdp, GstWebRTC)
-  - aiohttp
+  - aiohttp (only when --port is used)
 """
 
 import argparse
@@ -30,10 +29,7 @@ gi.require_version("GstSdp", "1.0")
 gi.require_version("GstWebRTC", "1.0")
 from gi.repository import Gst, GstSdp, GstWebRTC, GLib
 
-import aiohttp
-from aiohttp import web
-
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", stream=sys.stderr)
 logger = logging.getLogger("gamer")
 
 Gst.init(None)
@@ -46,34 +42,86 @@ class GamerPipeline:
         self._bitrate = bitrate
         self._pipe = None
         self._webrtcbin = None
-        self._ws = None
+        self._send = None  # async callable: (dict) -> awaitable
         self._loop = None
+        self._signal_lost = False
 
     def build(self, loop: asyncio.AbstractEventLoop):
         self._loop = loop
 
         encoder = self._detect_encoder()
+        # input-selector lets us swap between live v4l2 capture and a black
+        # placeholder source on the fly, so a V4 port switch / EDID drop
+        # doesn't tear down the WebRTC session. We point at video2 first;
+        # the bus error handler swaps to videotestsrc on capture failure.
+        # Both branches feed the same encoder->rtp->webrtcbin downstream.
         pipe_str = (
-            f"v4l2src device={self._device} "
+            f"input-selector name=sel "
+            f"! videoconvert ! videoscale "
             f"! video/x-raw,framerate={self._fps}/1 "
-            f"! videoconvert "
             f"! {encoder} "
             f"! video/x-h264,profile=constrained-baseline "
             f"! rtph264pay config-interval=-1 pt=96 "
             f"! application/x-rtp,media=video,encoding-name=H264,payload=96 "
             f"! webrtcbin name=webrtc bundle-policy=max-bundle "
-            f"  stun-server=stun://stun.l.google.com:19302"
+            f"  stun-server=stun://stun.l.google.com:19302 "
+            f"v4l2src device={self._device} name=cap "
+            f"! video/x-raw,framerate={self._fps}/1 "
+            f"! sel.sink_0 "
+            f"videotestsrc pattern=black is-live=true name=fallback "
+            f"! video/x-raw,framerate={self._fps}/1,width=1280,height=720 "
+            f"! sel.sink_1"
         )
         logger.info("Pipeline: %s", pipe_str)
         self._pipe = Gst.parse_launch(pipe_str)
         self._webrtcbin = self._pipe.get_by_name("webrtc")
+        self._selector = self._pipe.get_by_name("sel")
+
+        # Start on the live capture branch (sink_0).
+        sink0 = self._selector.get_static_pad("sink_0")
+        self._selector.set_property("active-pad", sink0)
 
         self._webrtcbin.connect("on-negotiation-needed", self._on_negotiation_needed)
         self._webrtcbin.connect("on-ice-candidate", self._on_ice_candidate)
         self._webrtcbin.connect("pad-added", self._on_pad_added)
-
-        # Disable jitter buffer for minimum latency
         self._webrtcbin.set_property("latency", 0)
+
+        # Watch the bus for v4l2src errors -> swap to black fallback,
+        # then poll for the device coming back and swap back.
+        bus = self._pipe.get_bus()
+        bus.add_signal_watch()
+        bus.connect("message::error", self._on_bus_error)
+
+    def _on_bus_error(self, _bus, message):
+        src_name = message.src.get_name() if message.src else "?"
+        err, dbg = message.parse_error()
+        logger.warning("Bus error from %s: %s", src_name, err)
+        # If the capture source died (port switch / EDID drop), swap to the
+        # black fallback branch without tearing down the encoder/webrtc.
+        if src_name in ("cap", "v4l2src0") and not self._signal_lost:
+            self._signal_lost = True
+            self._emit({"type": "signal_lost", "src": src_name})
+            sink1 = self._selector.get_static_pad("sink_1")
+            self._selector.set_property("active-pad", sink1)
+            # Try to recover the capture branch periodically.
+            GLib.timeout_add(1000, self._try_recover_capture)
+
+    def _try_recover_capture(self):
+        cap = self._pipe.get_by_name("cap")
+        if not cap:
+            return False
+        # Re-trigger READY->PLAYING on the capture branch.
+        cap.set_state(Gst.State.READY)
+        cap.set_state(Gst.State.PLAYING)
+        ret, state, _pending = cap.get_state(timeout=Gst.SECOND)
+        if ret == Gst.StateChangeReturn.SUCCESS and state == Gst.State.PLAYING:
+            sink0 = self._selector.get_static_pad("sink_0")
+            self._selector.set_property("active-pad", sink0)
+            self._signal_lost = False
+            self._emit({"type": "signal_restored"})
+            logger.info("v4l2src recovered, swapped back to live capture")
+            return False  # stop the timer
+        return True  # keep polling
 
     def _detect_encoder(self) -> str:
         hw = Gst.ElementFactory.find("v4l2h264enc")
@@ -99,11 +147,16 @@ class GamerPipeline:
             self._pipe.set_state(Gst.State.NULL)
             logger.info("Pipeline stopped")
 
-    def set_ws(self, ws):
-        self._ws = ws
+    def set_sender(self, send):
+        """send(dict) -> awaitable. Called from any thread; scheduled on _loop."""
+        self._send = send
+
+    def _emit(self, msg: dict):
+        if self._send and self._loop:
+            asyncio.run_coroutine_threadsafe(self._send(msg), self._loop)
 
     def _on_negotiation_needed(self, webrtcbin):
-        logger.info("Negotiation needed — creating offer")
+        logger.info("Negotiation needed -- creating offer")
         promise = Gst.Promise.new_with_change_func(self._on_offer_created)
         webrtcbin.emit("create-offer", None, promise)
 
@@ -114,22 +167,14 @@ class GamerPipeline:
         self._webrtcbin.emit("set-local-description", offer, None)
         sdp_text = offer.sdp.as_text()
         logger.info("SDP offer created (%d chars)", len(sdp_text))
-        if self._ws and self._loop:
-            asyncio.run_coroutine_threadsafe(
-                self._ws.send_json({"type": "offer", "sdp": sdp_text}),
-                self._loop,
-            )
+        self._emit({"type": "offer", "sdp": sdp_text})
 
     def _on_ice_candidate(self, webrtcbin, mline_index, candidate):
-        if self._ws and self._loop:
-            asyncio.run_coroutine_threadsafe(
-                self._ws.send_json({
-                    "type": "ice",
-                    "candidate": candidate,
-                    "sdpMLineIndex": mline_index,
-                }),
-                self._loop,
-            )
+        self._emit({
+            "type": "ice",
+            "candidate": candidate,
+            "sdpMLineIndex": mline_index,
+        })
 
     def _on_pad_added(self, webrtcbin, pad):
         logger.info("Pad added: %s", pad.get_name())
@@ -160,19 +205,24 @@ class GamerServer:
         self._pipeline = None
 
     async def _ws_handler(self, request):
+        import aiohttp
+        from aiohttp import web
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         logger.info("WebSocket client connected")
 
         loop = asyncio.get_event_loop()
 
-        # Build a fresh pipeline for each connection (1:1 streaming)
         if self._pipeline:
             self._pipeline.stop()
 
         self._pipeline = GamerPipeline(self._device, self._fps, self._bitrate)
         self._pipeline.build(loop)
-        self._pipeline.set_ws(ws)
+
+        async def send(msg):
+            await ws.send_json(msg)
+
+        self._pipeline.set_sender(send)
         self._pipeline.start()
 
         try:
@@ -191,9 +241,11 @@ class GamerServer:
         return ws
 
     async def _index_handler(self, request):
+        from aiohttp import web
         return web.Response(text=_INDEX_HTML, content_type="text/html")
 
     def run(self):
+        from aiohttp import web
         app = web.Application()
         app.router.add_get("/", self._index_handler)
         app.router.add_get("/ws", self._ws_handler)
@@ -289,16 +341,67 @@ connect();
 """
 
 
+async def run_stdio(device: str, fps: int, bitrate: int):
+    """Bridge signaling over stdin/stdout JSON-line frames.
+
+    kvmd parents this process: it forwards browser-WS messages into stdin,
+    and reads stdout for SDP offer / ICE candidates / signal-loss events
+    to forward back to the browser WS. One frame per line.
+    """
+    loop = asyncio.get_event_loop()
+    pipeline = GamerPipeline(device, fps, bitrate)
+    pipeline.build(loop)
+
+    # Writer: a coroutine that emits one JSON line to stdout.
+    write_lock = asyncio.Lock()
+
+    async def send(msg: dict) -> None:
+        async with write_lock:
+            sys.stdout.write(json.dumps(msg) + "\n")
+            sys.stdout.flush()
+
+    pipeline.set_sender(send)
+    pipeline.start()
+
+    # Reader: stdin lines -> pipeline. Use a thread executor since
+    # sys.stdin.readline() is blocking.
+    def read_line():
+        return sys.stdin.readline()
+
+    try:
+        while True:
+            line = await loop.run_in_executor(None, read_line)
+            if not line:
+                logger.info("stdin EOF, shutting down")
+                break
+            try:
+                msg = json.loads(line.strip())
+            except json.JSONDecodeError as ex:
+                logger.warning("Bad JSON on stdin: %s", ex)
+                continue
+            await pipeline.handle_message(msg)
+    finally:
+        pipeline.stop()
+
+
 def main():
     parser = argparse.ArgumentParser(description="PiKVM Gamer Mode Streamer")
     parser.add_argument("--device", default="/dev/video0", help="V4L2 device")
-    parser.add_argument("--port", type=int, default=8765, help="WebSocket port")
     parser.add_argument("--fps", type=int, default=60, help="Target framerate")
     parser.add_argument("--bitrate", type=int, default=5000, help="H.264 bitrate (kbps)")
+    parser.add_argument("--port", type=int, default=0,
+                        help="If >0, run standalone HTTP server on this port "
+                             "(legacy spike mode). Default 0 = stdio mode.")
     args = parser.parse_args()
 
-    server = GamerServer(args.device, args.fps, args.bitrate, args.port)
-    server.run()
+    if args.port > 0:
+        # Standalone spike mode: import aiohttp on demand.
+        from aiohttp import web  # noqa: F401
+        server = GamerServer(args.device, args.fps, args.bitrate, args.port)
+        server.run()
+    else:
+        # stdio mode: kvmd-managed.
+        asyncio.run(run_stdio(args.device, args.fps, args.bitrate))
 
 
 if __name__ == "__main__":

--- a/kvmd/apps/_scheme.py
+++ b/kvmd/apps/_scheme.py
@@ -362,7 +362,16 @@ def make_config_scheme() -> dict:
             },
 
             "streamer": {
+                # "default" = ustreamer (+ optional Janus, the legacy path).
+                # "gamer"   = direct GStreamer webrtcbin pipeline, no Janus.
+                "mode":    Option("default", type=valid_stripped_string_not_empty),
                 "forever": Option(False, type=valid_bool),
+
+                "gamer": {
+                    "device":  Option("/dev/video0", type=valid_abs_path),
+                    "fps":     Option(60,   type=valid_stream_fps),
+                    "bitrate": Option(5000, type=valid_stream_h264_bitrate),
+                },
 
                 "reset_delay":    Option(1.0,  type=valid_float_f0),
                 "shutdown_delay": Option(10.0, type=valid_float_f01),

--- a/kvmd/apps/kvmd/__init__.py
+++ b/kvmd/apps/kvmd/__init__.py
@@ -31,6 +31,7 @@ from .info import InfoManager
 from .logreader import LogReader
 from .ugpio import UserGpio
 from .streamer import Streamer
+from .streamer.gamer import GamerStreamer
 from .snapshoter import Snapshoter
 from .ocr import Ocr
 from .switch import Switch
@@ -55,13 +56,24 @@ def main() -> None:
 
     hid = get_hid_class(config.hid.type)(config.hid)
 
-    streamer = Streamer(
-        **config.streamer._unpack(ignore=["forever", "desired_fps", "resolution", "h264_bitrate", "h264_gop"]),
-        **config.streamer.resolution._unpack(),
-        **config.streamer.desired_fps._unpack(),
-        **config.streamer.h264_bitrate._unpack(),
-        **config.streamer.h264_gop._unpack(),
-    )
+    streamer: (Streamer | GamerStreamer)
+    if config.streamer.mode == "gamer":
+        streamer = GamerStreamer(
+            device=config.streamer.gamer.device,
+            fps=config.streamer.gamer.fps,
+            bitrate=config.streamer.gamer.bitrate,
+        )
+    else:
+        streamer = Streamer(
+            **config.streamer._unpack(ignore=[
+                "mode", "forever", "gamer",
+                "desired_fps", "resolution", "h264_bitrate", "h264_gop",
+            ]),
+            **config.streamer.resolution._unpack(),
+            **config.streamer.desired_fps._unpack(),
+            **config.streamer.h264_bitrate._unpack(),
+            **config.streamer.h264_gop._unpack(),
+        )
 
     KvmdServer(
         auth=AuthManager(

--- a/kvmd/apps/kvmd/server.py
+++ b/kvmd/apps/kvmd/server.py
@@ -64,6 +64,7 @@ from .info import InfoManager
 from .logreader import LogReader
 from .ugpio import UserGpio
 from .streamer import Streamer
+from .streamer.gamer import GamerStreamer
 from .snapshoter import Snapshoter
 from .ocr import Ocr
 from .switch import Switch
@@ -156,7 +157,7 @@ class KvmdServer(HttpServer):  # pylint: disable=too-many-arguments,too-many-ins
         hid: BaseHid,
         atx: BaseAtx,
         msd: BaseMsd,
-        streamer: Streamer,
+        streamer: "Streamer | GamerStreamer",
         snapshoter: Snapshoter,
 
         allow_redirects: list[str],
@@ -265,6 +266,23 @@ class KvmdServer(HttpServer):  # pylint: disable=too-many-arguments,too-many-ins
     @exposed_ws(0)
     async def __ws_bin_ping_handler(self, ws: WsSession, _: bytes) -> None:
         await ws.send_bin(255, b"")  # Ping-pong
+
+    # ===== GAMER-MODE WEBRTC SIGNALING
+    #
+    # When streamer.mode == "gamer", the browser exchanges SDP / ICE with the
+    # GamerStreamer subprocess directly through this handler. kvmd is a
+    # transparent bridge: browser -> subprocess via handle_browser_message,
+    # subprocess -> browser via ws.send_event("webrtc_signal", ...).
+
+    @exposed_ws("webrtc_signal")
+    async def __ws_webrtc_signal_handler(self, ws: WsSession, msg: dict) -> None:
+        if not isinstance(self.__streamer, GamerStreamer):
+            return
+        # First message from any browser session also starts/attaches the pipeline.
+        await self.__streamer.ensure_start(
+            lambda outbound: ws.send_event("webrtc_signal", outbound),
+        )
+        await self.__streamer.handle_browser_message(msg)
 
     # ===== SYSTEM STUFF
 

--- a/kvmd/apps/kvmd/streamer/gamer.py
+++ b/kvmd/apps/kvmd/streamer/gamer.py
@@ -21,53 +21,81 @@
 
 
 """
-Gamer Mode Streamer — low-latency WebRTC video via GStreamer webrtcbin.
+Gamer Mode Streamer -- low-latency WebRTC video via GStreamer webrtcbin.
 
 Replaces the ustreamer + Janus pipeline with a direct GStreamer pipeline
 that establishes a 1:1 P2P WebRTC connection to the browser. No SFU
 middleman, no jitter buffers, minimum latency.
 
-The pipeline runs as a subprocess managed by kvmd. WebRTC signaling
-(SDP offer/answer, ICE candidates) is bridged through kvmd's existing
-WebSocket connection to the browser.
+The pipeline runs as a subprocess (contrib/gamer-mode/gamer_streamer.py)
+managed by kvmd. Signaling is over the subprocess's stdin/stdout (JSON
+lines): kvmd bridges those frames to/from the browser via its existing
+/ws WebSocket.
 
-Pipeline: v4l2src → v4l2h264enc (or x264enc fallback) → rtph264pay → webrtcbin
+Pipeline: v4l2src -> v4l2h264enc (or x264enc fallback) -> rtph264pay -> webrtcbin
 
-Requires: GStreamer 1.x, gst-plugins-bad (webrtcbin), PyGObject.
+Requires on the host: GStreamer 1.x with gst-plugins-bad (webrtcbin)
+and PyGObject (gi.repository.Gst, GstSdp, GstWebRTC).
 """
 
 import asyncio
 import json
-import logging
-import subprocess
 import os
 import signal
+import sys
 
 from typing import Any
+from typing import Awaitable
+from typing import Callable
 
 from ....logging import get_logger
 
 
+SignalSender = Callable[[dict], Awaitable[None]]
+
+
 class GamerStreamer:
-    """Manages the gamer-mode GStreamer subprocess and bridges signaling."""
+    """Manages the gamer-mode GStreamer subprocess and bridges signaling.
+
+    The expected lifecycle:
+      1. ensure_start() with a send-to-browser callback.
+      2. handle_browser_message(msg) for each SDP answer / ICE from the browser.
+      3. ensure_stop() on teardown.
+    """
 
     def __init__(
         self,
         device: str = "/dev/video0",
         fps: int = 60,
         bitrate: int = 5000,
+        script_path: str = "",
     ) -> None:
         self.__device = device
         self.__fps = fps
         self.__bitrate = bitrate
-        self.__proc: (subprocess.Popen | None) = None  # type: ignore
-        self.__ws_send = None  # callback to send to browser WS
-        self.__reader_task = None
+
+        if script_path:
+            self.__script_path = script_path
+        else:
+            # contrib/gamer-mode/gamer_streamer.py relative to this file.
+            here = os.path.dirname(os.path.abspath(__file__))
+            self.__script_path = os.path.normpath(os.path.join(
+                here, "..", "..", "..", "..",
+                "contrib", "gamer-mode", "gamer_streamer.py",
+            ))
+
+        self.__proc: (asyncio.subprocess.Process | None) = None
+        self.__reader_task: (asyncio.Task | None) = None
+        self.__send_to_browser: (SignalSender | None) = None
+
+    # =====
 
     async def get_state(self) -> dict:
+        alive = (self.__proc is not None and self.__proc.returncode is None)
         return {
             "streamer": {
-                "online": self.__proc is not None and self.__proc.poll() is None,
+                "online": alive,
+                "encoder": "gstreamer-webrtcbin",
             },
             "features": {
                 "quality": False,
@@ -80,51 +108,76 @@ class GamerStreamer:
             },
         }
 
-    async def ensure_start(self, ws_send_callback: Any = None) -> None:
-        """Start the GStreamer subprocess if not already running."""
-        if self.__proc and self.__proc.poll() is None:
+    async def ensure_start(self, send_to_browser: SignalSender) -> None:
+        """Start the GStreamer subprocess. send_to_browser is called for
+        each SDP offer / ICE candidate / signal event from the pipeline."""
+        if self.__proc and self.__proc.returncode is None:
             return
 
-        self.__ws_send = ws_send_callback
-
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-        script = os.path.join(script_dir, "..", "..", "..", "contrib", "gamer-mode", "gamer_streamer.py")
-
-        # The subprocess runs the standalone gamer_streamer.py which handles
-        # GStreamer + its own signaling WebSocket on a local port. kvmd proxies
-        # the browser's WebRTC signaling messages to this local port.
+        self.__send_to_browser = send_to_browser
         cmd = [
-            "python3", script,
+            sys.executable, self.__script_path,
             "--device", self.__device,
             "--fps", str(self.__fps),
             "--bitrate", str(self.__bitrate),
-            "--port", "8765",
+            # No --port arg -> stdio mode.
         ]
-
         logger = get_logger(0)
         logger.info("Starting gamer-mode streamer: %s", " ".join(cmd))
-        self.__proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        self.__proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        self.__reader_task = asyncio.create_task(self.__read_loop())
 
     async def ensure_stop(self) -> None:
-        if self.__proc:
-            logger = get_logger(0)
-            logger.info("Stopping gamer-mode streamer (pid=%d)", self.__proc.pid)
-            self.__proc.send_signal(signal.SIGTERM)
+        logger = get_logger(0)
+        if self.__reader_task:
+            self.__reader_task.cancel()
             try:
-                self.__proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
+                await self.__reader_task
+            except asyncio.CancelledError:
+                pass
+            self.__reader_task = None
+        if self.__proc and self.__proc.returncode is None:
+            logger.info("Stopping gamer-mode streamer (pid=%d)", self.__proc.pid)
+            try:
+                self.__proc.send_signal(signal.SIGTERM)
+                await asyncio.wait_for(self.__proc.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.warning("Gamer-mode streamer didn't exit, killing")
                 self.__proc.kill()
-            self.__proc = None
+                await self.__proc.wait()
+        self.__proc = None
+        self.__send_to_browser = None
 
     async def ensure_restart(self) -> None:
+        sender = self.__send_to_browser
         await self.ensure_stop()
-        await self.ensure_start(self.__ws_send)
+        if sender:
+            await self.ensure_start(sender)
+
+    async def handle_browser_message(self, msg: dict) -> None:
+        """Forward an SDP answer / ICE candidate from the browser into
+        the GStreamer subprocess via its stdin."""
+        if not self.__proc or not self.__proc.stdin:
+            return
+        line = (json.dumps(msg) + "\n").encode("utf-8")
+        try:
+            self.__proc.stdin.write(line)
+            await self.__proc.stdin.drain()
+        except (BrokenPipeError, ConnectionResetError):
+            get_logger(0).warning("Gamer-mode streamer stdin closed")
+
+    # =====
 
     def set_params(self, params: dict) -> None:
         if "desired_fps" in params:
-            self.__fps = params["desired_fps"]
+            self.__fps = int(params["desired_fps"])
         if "h264_bitrate" in params:
-            self.__bitrate = params["h264_bitrate"]
+            self.__bitrate = int(params["h264_bitrate"])
 
     def get_params(self) -> dict:
         return {
@@ -132,8 +185,29 @@ class GamerStreamer:
             "h264_bitrate": self.__bitrate,
         }
 
-    async def poll_state(self):
-        """Yield state changes (placeholder for compatibility)."""
-        while True:
-            yield await self.get_state()
-            await asyncio.sleep(1.0)
+    # =====
+
+    async def __read_loop(self) -> None:
+        """Read JSON lines from the subprocess stdout and forward to the browser."""
+        logger = get_logger(0)
+        assert self.__proc and self.__proc.stdout
+        try:
+            while True:
+                line = await self.__proc.stdout.readline()
+                if not line:
+                    logger.info("Gamer-mode streamer stdout EOF")
+                    break
+                try:
+                    msg = json.loads(line.decode("utf-8").strip())
+                except json.JSONDecodeError as ex:
+                    logger.warning("Bad JSON from gamer-mode streamer: %s", ex)
+                    continue
+                if self.__send_to_browser:
+                    try:
+                        await self.__send_to_browser(msg)
+                    except Exception:  # pylint: disable=broad-except
+                        logger.exception("send_to_browser failed")
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Gamer-mode reader loop crashed")

--- a/kvmd/apps/kvmd/streamer/gamer.py
+++ b/kvmd/apps/kvmd/streamer/gamer.py
@@ -1,0 +1,139 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+"""
+Gamer Mode Streamer — low-latency WebRTC video via GStreamer webrtcbin.
+
+Replaces the ustreamer + Janus pipeline with a direct GStreamer pipeline
+that establishes a 1:1 P2P WebRTC connection to the browser. No SFU
+middleman, no jitter buffers, minimum latency.
+
+The pipeline runs as a subprocess managed by kvmd. WebRTC signaling
+(SDP offer/answer, ICE candidates) is bridged through kvmd's existing
+WebSocket connection to the browser.
+
+Pipeline: v4l2src → v4l2h264enc (or x264enc fallback) → rtph264pay → webrtcbin
+
+Requires: GStreamer 1.x, gst-plugins-bad (webrtcbin), PyGObject.
+"""
+
+import asyncio
+import json
+import logging
+import subprocess
+import os
+import signal
+
+from typing import Any
+
+from ....logging import get_logger
+
+
+class GamerStreamer:
+    """Manages the gamer-mode GStreamer subprocess and bridges signaling."""
+
+    def __init__(
+        self,
+        device: str = "/dev/video0",
+        fps: int = 60,
+        bitrate: int = 5000,
+    ) -> None:
+        self.__device = device
+        self.__fps = fps
+        self.__bitrate = bitrate
+        self.__proc: (subprocess.Popen | None) = None  # type: ignore
+        self.__ws_send = None  # callback to send to browser WS
+        self.__reader_task = None
+
+    async def get_state(self) -> dict:
+        return {
+            "streamer": {
+                "online": self.__proc is not None and self.__proc.poll() is None,
+            },
+            "features": {
+                "quality": False,
+                "resolution": False,
+                "h264": True,
+            },
+            "params": {
+                "desired_fps": self.__fps,
+                "h264_bitrate": self.__bitrate,
+            },
+        }
+
+    async def ensure_start(self, ws_send_callback: Any = None) -> None:
+        """Start the GStreamer subprocess if not already running."""
+        if self.__proc and self.__proc.poll() is None:
+            return
+
+        self.__ws_send = ws_send_callback
+
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        script = os.path.join(script_dir, "..", "..", "..", "contrib", "gamer-mode", "gamer_streamer.py")
+
+        # The subprocess runs the standalone gamer_streamer.py which handles
+        # GStreamer + its own signaling WebSocket on a local port. kvmd proxies
+        # the browser's WebRTC signaling messages to this local port.
+        cmd = [
+            "python3", script,
+            "--device", self.__device,
+            "--fps", str(self.__fps),
+            "--bitrate", str(self.__bitrate),
+            "--port", "8765",
+        ]
+
+        logger = get_logger(0)
+        logger.info("Starting gamer-mode streamer: %s", " ".join(cmd))
+        self.__proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    async def ensure_stop(self) -> None:
+        if self.__proc:
+            logger = get_logger(0)
+            logger.info("Stopping gamer-mode streamer (pid=%d)", self.__proc.pid)
+            self.__proc.send_signal(signal.SIGTERM)
+            try:
+                self.__proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.__proc.kill()
+            self.__proc = None
+
+    async def ensure_restart(self) -> None:
+        await self.ensure_stop()
+        await self.ensure_start(self.__ws_send)
+
+    def set_params(self, params: dict) -> None:
+        if "desired_fps" in params:
+            self.__fps = params["desired_fps"]
+        if "h264_bitrate" in params:
+            self.__bitrate = params["h264_bitrate"]
+
+    def get_params(self) -> dict:
+        return {
+            "desired_fps": self.__fps,
+            "h264_bitrate": self.__bitrate,
+        }
+
+    async def poll_state(self):
+        """Yield state changes (placeholder for compatibility)."""
+        while True:
+            yield await self.get_state()
+            await asyncio.sleep(1.0)

--- a/web/share/js/kvm/stream.js
+++ b/web/share/js/kvm/stream.js
@@ -29,6 +29,7 @@ import {wm} from "../wm.js";
 import {JanusStreamer} from "./stream_janus.js";
 import {MediaStreamer} from "./stream_media.js";
 import {MjpegStreamer} from "./stream_mjpeg.js";
+import {WebrtcStreamer} from "./stream_webrtc.js";
 
 
 export function Streamer() {
@@ -344,9 +345,13 @@ export function Streamer() {
 			let allow_mic = (tools.feature.isEnabled($("stream-mic")) && $("stream-mic-switch").checked);
 			let allow_cam = (tools.feature.isEnabled($("stream-cam")) && $("stream-cam-switch").checked);
 			__streamer = new JanusStreamer(__setActive, __setInactive, __setInfo, __organizeHook, orient, allow_audio, allow_mic, allow_cam);
-			// Firefox doesn't support RTP orientation:
-			//  - https://bugzilla.mozilla.org/show_bug.cgi?id=1316448
 			tools.feature.setEnabled($("stream-orient"), !tools.browser.is_firefox);
+		} else if (mode === "webrtc") {
+			__streamer = new WebrtcStreamer(__setActive, __setInactive, __setInfo, __organizeHook, orient);
+			tools.feature.setEnabled($("stream-orient"), true);
+			tools.feature.setEnabled($("stream-audio"), false);
+			tools.feature.setEnabled($("stream-mic"), false);
+			tools.feature.setEnabled($("stream-cam"), false);
 		} else {
 			if (mode === "media") {
 				__streamer = new MediaStreamer(__setActive, __setInactive, __setInfo, __organizeHook, orient);
@@ -355,9 +360,9 @@ export function Streamer() {
 				__streamer = new MjpegStreamer(__setActive, __setInactive, __setInfo, __organizeHook);
 				tools.feature.setEnabled($("stream-orient"), false);
 			}
-			tools.feature.setEnabled($("stream-audio"), false); // Enabling in stream_janus.js
-			tools.feature.setEnabled($("stream-mic"), false); // Ditto
-			tools.feature.setEnabled($("stream-cam"), false); // Ditto
+			tools.feature.setEnabled($("stream-audio"), false);
+			tools.feature.setEnabled($("stream-mic"), false);
+			tools.feature.setEnabled($("stream-cam"), false);
 		}
 		if (__isStreamRequired()) {
 			__streamer.ensureStream((__state && __state.streamer !== undefined) ? __state.streamer : null);
@@ -370,7 +375,7 @@ export function Streamer() {
 		if (mode !== __streamer.getMode()) {
 			tools.hidden.setVisible($("stream-canvas"), (mode === "media"));
 			tools.hidden.setVisible($("stream-image"), (mode === "mjpeg"));
-			tools.hidden.setVisible($("stream-video"), (mode === "janus"));
+			tools.hidden.setVisible($("stream-video"), (mode === "janus" || mode === "webrtc"));
 			__resetStream(mode);
 		}
 	};

--- a/web/share/js/kvm/stream_webrtc.js
+++ b/web/share/js/kvm/stream_webrtc.js
@@ -1,0 +1,163 @@
+/*****************************************************************************
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+*****************************************************************************/
+
+
+"use strict";
+
+
+import {tools, $} from "../tools.js";
+
+
+export function WebrtcStreamer(__setActive, __setInactive, __setInfo, __organizeHook, __orient) {
+	var self = this;
+
+	/************************************************************************/
+
+	var __pc = null;
+	var __ws = null;
+	var __retry_timeout = null;
+	var __ensuring = false;
+
+	/************************************************************************/
+
+	self.getOrientation = () => __orient;
+	self.isAudioAllowed = () => false;
+	self.isMicAllowed = () => false;
+	self.isCamAllowed = () => false;
+
+	self.getName = function() {
+		return "WebRTC Direct";
+	};
+
+	self.getMode = function() {
+		return "webrtc";
+	};
+
+	self.ensureStream = function(state) {
+		if (__ensuring) return;
+		__ensuring = true;
+		__connect();
+	};
+
+	self.stopStream = function() {
+		__ensuring = false;
+		__cleanup();
+	};
+
+	/************************************************************************/
+
+	var __connect = function() {
+		// Connect to the gamer-mode streamer's signaling WebSocket.
+		// In production this would go through kvmd's /ws, but for the
+		// standalone spike it connects directly to port 8765.
+		let proto = (location.protocol === "https:" ? "wss:" : "ws:");
+		let url = proto + "//" + location.hostname + ":8765/ws";
+
+		__ws = new WebSocket(url);
+
+		__ws.onopen = function() {
+			__setInfo(false, false, "Gamer mode: waiting for offer...");
+		};
+
+		__ws.onmessage = async function(ev) {
+			let msg = JSON.parse(ev.data);
+
+			if (msg.type === "offer") {
+				__setInfo(false, false, "Got offer, creating answer...");
+
+				__pc = new RTCPeerConnection({
+					iceServers: [{urls: "stun:stun.l.google.com:19302"}],
+				});
+
+				__pc.ontrack = function(event) {
+					__setActive();
+					__setInfo(false, false, "Gamer mode: streaming!");
+					$("stream-video").srcObject = event.streams[0];
+				};
+
+				__pc.onicecandidate = function(event) {
+					if (event.candidate && __ws) {
+						__ws.send(JSON.stringify({
+							type: "ice",
+							candidate: event.candidate.candidate,
+							sdpMLineIndex: event.candidate.sdpMLineIndex,
+						}));
+					}
+				};
+
+				__pc.oniceconnectionstatechange = function() {
+					let state = __pc.iceConnectionState;
+					if (state === "failed" || state === "disconnected" || state === "closed") {
+						__setInactive();
+						__setInfo(false, false, "Gamer mode: ICE " + state);
+						__scheduleRetry();
+					}
+				};
+
+				await __pc.setRemoteDescription({type: "offer", sdp: msg.sdp});
+				let answer = await __pc.createAnswer();
+				await __pc.setLocalDescription(answer);
+				__ws.send(JSON.stringify({type: "answer", sdp: answer.sdp}));
+			}
+
+			else if (msg.type === "ice") {
+				if (__pc && msg.candidate) {
+					await __pc.addIceCandidate({
+						candidate: msg.candidate,
+						sdpMLineIndex: msg.sdpMLineIndex,
+					});
+				}
+			}
+		};
+
+		__ws.onclose = function() {
+			__setInactive();
+			__scheduleRetry();
+		};
+
+		__ws.onerror = function() {
+			if (__ws) __ws.close();
+		};
+	};
+
+	var __cleanup = function() {
+		if (__retry_timeout) {
+			clearTimeout(__retry_timeout);
+			__retry_timeout = null;
+		}
+		if (__pc) {
+			__pc.close();
+			__pc = null;
+		}
+		if (__ws) {
+			__ws.close();
+			__ws = null;
+		}
+		__setInactive();
+	};
+
+	var __scheduleRetry = function() {
+		if (!__ensuring) return;
+		__cleanup();
+		__ensuring = true;  // restore after cleanup cleared it
+		__retry_timeout = setTimeout(__connect, 2000);
+	};
+}

--- a/web/share/js/kvm/stream_webrtc.js
+++ b/web/share/js/kvm/stream_webrtc.js
@@ -64,78 +64,90 @@ export function WebrtcStreamer(__setActive, __setInactive, __setInfo, __organize
 
 	/************************************************************************/
 
+	// Signaling rides on kvmd's existing /ws WebSocket (event_type "webrtc_signal").
+	// kvmd transparently bridges these frames to the GamerStreamer subprocess.
+
 	var __connect = function() {
-		// Connect to the gamer-mode streamer's signaling WebSocket.
-		// In production this would go through kvmd's /ws, but for the
-		// standalone spike it connects directly to port 8765.
 		let proto = (location.protocol === "https:" ? "wss:" : "ws:");
-		let url = proto + "//" + location.hostname + ":8765/ws";
-
+		let url = proto + "//" + location.host + "/api/ws?stream=0";
 		__ws = new WebSocket(url);
-
 		__ws.onopen = function() {
-			__setInfo(false, false, "Gamer mode: waiting for offer...");
+			__setInfo(false, false, "Gamer mode: requesting offer...");
+			// Poke the server to start the pipeline; the message body is unused
+			// on the very first call (it just triggers ensure_start in the handler).
+			__ws.send(JSON.stringify({event_type: "webrtc_signal", event: {type: "hello"}}));
 		};
-
-		__ws.onmessage = async function(ev) {
-			let msg = JSON.parse(ev.data);
-
-			if (msg.type === "offer") {
-				__setInfo(false, false, "Got offer, creating answer...");
-
-				__pc = new RTCPeerConnection({
-					iceServers: [{urls: "stun:stun.l.google.com:19302"}],
-				});
-
-				__pc.ontrack = function(event) {
-					__setActive();
-					__setInfo(false, false, "Gamer mode: streaming!");
-					$("stream-video").srcObject = event.streams[0];
-				};
-
-				__pc.onicecandidate = function(event) {
-					if (event.candidate && __ws) {
-						__ws.send(JSON.stringify({
-							type: "ice",
-							candidate: event.candidate.candidate,
-							sdpMLineIndex: event.candidate.sdpMLineIndex,
-						}));
-					}
-				};
-
-				__pc.oniceconnectionstatechange = function() {
-					let state = __pc.iceConnectionState;
-					if (state === "failed" || state === "disconnected" || state === "closed") {
-						__setInactive();
-						__setInfo(false, false, "Gamer mode: ICE " + state);
-						__scheduleRetry();
-					}
-				};
-
-				await __pc.setRemoteDescription({type: "offer", sdp: msg.sdp});
-				let answer = await __pc.createAnswer();
-				await __pc.setLocalDescription(answer);
-				__ws.send(JSON.stringify({type: "answer", sdp: answer.sdp}));
-			}
-
-			else if (msg.type === "ice") {
-				if (__pc && msg.candidate) {
-					await __pc.addIceCandidate({
-						candidate: msg.candidate,
-						sdpMLineIndex: msg.sdpMLineIndex,
-					});
-				}
-			}
-		};
-
+		__ws.onmessage = (ev) => __onSignal(JSON.parse(ev.data));
 		__ws.onclose = function() {
 			__setInactive();
 			__scheduleRetry();
 		};
-
 		__ws.onerror = function() {
 			if (__ws) __ws.close();
 		};
+	};
+
+	var __sendSignal = function(payload) {
+		if (__ws && __ws.readyState === WebSocket.OPEN) {
+			__ws.send(JSON.stringify({event_type: "webrtc_signal", event: payload}));
+		}
+	};
+
+	var __onSignal = async function(frame) {
+		// kvmd wraps events as {event_type: "webrtc_signal", event: {...}}
+		if (frame.event_type !== "webrtc_signal") return;
+		let msg = frame.event;
+
+		if (msg.type === "offer") {
+			__setInfo(false, false, "Got offer, creating answer...");
+			__pc = new RTCPeerConnection({
+				iceServers: [{urls: "stun:stun.l.google.com:19302"}],
+			});
+
+			__pc.ontrack = function(event) {
+				__setActive();
+				__setInfo(false, false, "Gamer mode: streaming!");
+				$("stream-video").srcObject = event.streams[0];
+			};
+
+			__pc.onicecandidate = function(event) {
+				if (event.candidate) {
+					__sendSignal({
+						type: "ice",
+						candidate: event.candidate.candidate,
+						sdpMLineIndex: event.candidate.sdpMLineIndex,
+					});
+				}
+			};
+
+			__pc.oniceconnectionstatechange = function() {
+				let state = __pc.iceConnectionState;
+				if (state === "failed" || state === "disconnected" || state === "closed") {
+					__setInactive();
+					__setInfo(false, false, "Gamer mode: ICE " + state);
+					__scheduleRetry();
+				}
+			};
+
+			await __pc.setRemoteDescription({type: "offer", sdp: msg.sdp});
+			let answer = await __pc.createAnswer();
+			await __pc.setLocalDescription(answer);
+			__sendSignal({type: "answer", sdp: answer.sdp});
+		}
+		else if (msg.type === "ice") {
+			if (__pc && msg.candidate) {
+				await __pc.addIceCandidate({
+					candidate: msg.candidate,
+					sdpMLineIndex: msg.sdpMLineIndex,
+				});
+			}
+		}
+		else if (msg.type === "signal_lost") {
+			__setInfo(false, false, "Gamer mode: capture signal lost (port switch?)");
+		}
+		else if (msg.type === "signal_restored") {
+			__setInfo(false, false, "Gamer mode: streaming!");
+		}
 	};
 
 	var __cleanup = function() {


### PR DESCRIPTION
## Gamer Mode: Low-Latency WebRTC Streaming

Direct WebRTC streaming mode that bypasses the Janus SFU entirely, using GStreamer's `webrtcbin` for a 1:1 P2P connection between the Pi and the browser.

### Why

Current pipeline (ustreamer -> Janus -> browser) adds latency through Janus's jitter buffers and SFU processing. For single-user / gaming scenarios that overhead is unnecessary.

```
Default:  capture -> ustreamer -> Janus (SFU) -> browser
Gamer:    capture -> GStreamer -> webrtcbin (P2P) -> browser
```

### How to enable

```yaml
# /etc/kvmd/override.yaml
kvmd:
    streamer:
        mode: gamer
        gamer:
            device: /dev/video0
            fps: 60
            bitrate: 5000
```

Then select "WebRTC" in the stream mode picker.

### Components

- `contrib/gamer-mode/gamer_streamer.py`: GStreamer pipeline + signaling. Two transports:
  - `--port N` standalone (built-in aiohttp server + embedded HTML, for development).
  - default (no `--port`) stdio JSON-line frames, used when kvmd parents the process.
- `kvmd/apps/kvmd/streamer/gamer.py`: `GamerStreamer` subprocess manager. Spawns the script, reads stdout for SDP / ICE / signal events, writes browser responses to stdin.
- `kvmd/apps/_scheme.py`: `streamer.mode` + `streamer.gamer.*` config options.
- `kvmd/apps/kvmd/__init__.py`: branch on `streamer.mode` at startup.
- `kvmd/apps/kvmd/server.py`: `webrtc_signal` WebSocket event handler bridging browser <-> subprocess.
- `web/share/js/kvm/stream_webrtc.js`: browser-side WebRTC client (native `RTCPeerConnection`, no Janus lib). Signaling rides on the existing `/ws`.
- `web/share/js/kvm/stream.js`: "webrtc" stream-mode entry.

### Latency optimisations

- `latency=0` on `webrtcbin` (no jitter buffer)
- `tune=zerolatency` / `speed-preset=ultrafast` on x264enc fallback
- `config-interval=-1` on RTP payloader (SPS/PPS with every keyframe)
- No SFU hop (direct P2P ICE)
- Auto-detects Pi `v4l2h264enc` hardware encoder; falls back to `x264enc` only when absent

### V4 multi-port switch handling

The pipeline uses an `input-selector` with a live `v4l2src` (sink_0) and a `videotestsrc pattern=black` (sink_1). A bus error from the capture source (e.g. EDID renegotiation during a port switch) flips the selector to the black branch without tearing down the encoder or the WebRTC session. A recovery timer polls the capture branch every second and swaps back as soon as the device returns to PLAYING. The browser receives `signal_lost` and `signal_restored` frames in the meantime.

### What is NOT yet done

- Runtime mode toggle (currently config-time only; both pipelines would need to coexist)
- Audio support
- Tested on real Pi hardware (developed against the Lima VM with the x264enc fallback; `v4l2h264enc` path is auto-selected but unverified)

### Dependencies

- GStreamer 1.x with gst-plugins-bad (`webrtcbin`)
- PyGObject (`gi.repository.Gst`, `GstSdp`, `GstWebRTC`)
- aiohttp (already a kvmd dep; only used by the standalone `--port` mode)
