### PR TITLE
web: allow WebRTC microphone with audio capture for DIY PiKVM

### DIFF
--- a/contrib/diy-audio-backchannel/README.md
+++ b/contrib/diy-audio-backchannel/README.md
@@ -1,0 +1,46 @@
+# DIY Audio Backchannel
+
+Experimental mic-only audio backchannel for DIY PiKVM V2 on Raspberry Pi 4.
+
+The normal V3/V4 audio path expects HDMI audio capture from the target host and
+a USB UAC2 playback gadget for the browser microphone. A DIY V2 build usually
+does not have the HDMI audio capture side, but the outgoing browser microphone
+can still be useful for voice applications on the target host.
+
+This overlay enables only the USB microphone part of the OTG gadget:
+
+```yaml
+otg:
+    devices:
+        audio:
+            enabled: true
+            speakers:
+                enabled: false
+            mic:
+                enabled: true
+```
+
+Install it on the PiKVM as root:
+
+```console
+rw
+cp override.yaml /etc/kvmd/override.d/9900-diy-audio-backchannel.yaml
+reboot
+```
+
+After reboot:
+
+```console
+kvmd-otgconf
+aplay -l
+```
+
+Expected:
+
+- `kvmd-otgconf` lists `uac2.usb0`.
+- ALSA lists a playback device similar to `UAC2Gadget`.
+- The target host sees a USB microphone.
+
+This also needs a uStreamer Janus plugin that supports mic-only mode. Without
+that change the Web UI can show the microphone switch only when HDMI audio
+capture is available.

--- a/contrib/diy-audio-backchannel/override.yaml
+++ b/contrib/diy-audio-backchannel/override.yaml
@@ -1,0 +1,8 @@
+otg:
+    devices:
+        audio:
+            enabled: true
+            speakers:
+                enabled: false
+            mic:
+                enabled: true

--- a/web/share/js/kvm/stream.js
+++ b/web/share/js/kvm/stream.js
@@ -94,8 +94,6 @@ export function Streamer() {
 					__resetStream();
 				}
 			}
-			tools.el.setEnabled($("stream-mic-switch"), !!value);
-			tools.el.setEnabled($("stream-cam-switch"), !!value);
 		});
 
 		tools.storage.bindSimpleSwitch($("stream-mic-switch"), "stream.mic", false, function(allow_mic) {
@@ -250,6 +248,8 @@ export function Streamer() {
 				tools.feature.setEnabled($("stream-audio"), false);
 				tools.feature.setEnabled($("stream-mic"), false);
 				tools.feature.setEnabled($("stream-cam"), false);
+				tools.el.setEnabled($("stream-mic-switch"), false);
+				tools.el.setEnabled($("stream-cam-switch"), false);
 			}
 
 			let mode = tools.storage.get("stream.mode", "janus");
@@ -358,6 +358,8 @@ export function Streamer() {
 			tools.feature.setEnabled($("stream-audio"), false); // Enabling in stream_janus.js
 			tools.feature.setEnabled($("stream-mic"), false); // Ditto
 			tools.feature.setEnabled($("stream-cam"), false); // Ditto
+			tools.el.setEnabled($("stream-mic-switch"), false);
+			tools.el.setEnabled($("stream-cam-switch"), false);
 		}
 		if (__isStreamRequired()) {
 			__streamer.ensureStream((__state && __state.streamer !== undefined) ? __state.streamer : null);

--- a/web/share/js/kvm/stream_janus.js
+++ b/web/share/js/kvm/stream_janus.js
@@ -35,9 +35,6 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __organizeH
 
 	/************************************************************************/
 
-	__allow_mic = (__allow_audio && __allow_mic); // XXX: Mic only with audio
-	__allow_cam = (__allow_audio && __allow_cam); // XXX: Camera only with audio
-
 	var __stop = false;
 
 	var __janus = null;
@@ -61,12 +58,12 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __organizeH
 		let name = "WebRTC H.264";
 		if (__allow_audio) {
 			name += " + Audio";
-			if (__allow_mic) {
-				name += " + Mic";
-			}
-			if (__allow_cam) {
-				name += " + Cam";
-			}
+		}
+		if (__allow_mic) {
+			name += " + Mic";
+		}
+		if (__allow_cam) {
+			name += " + Cam";
 		}
 		return name;
 	};
@@ -288,6 +285,10 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __organizeH
 						tools.feature.setEnabled($("stream-audio"), msg.result.features.audio);
 						tools.feature.setEnabled($("stream-mic"), msg.result.features.mic);
 						tools.feature.setEnabled($("stream-cam"), msg.result.features.cam);
+						tools.el.setEnabled($("stream-mic-switch"), msg.result.features.mic);
+						tools.el.setEnabled($("stream-cam-switch"), msg.result.features.cam);
+						__allow_mic = (msg.result.features.mic && $("stream-mic-switch").checked);
+						__allow_cam = (msg.result.features.cam && $("stream-cam-switch").checked);
 						__ice = msg.result.features.ice;
 						__sendWatch();
 					}
@@ -310,9 +311,9 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __organizeH
 
 				if (jsep) {
 					__logInfo("Handling SDP:", jsep);
-					let tracks = [{"type": "video", "capture": (__allow_audio && __allow_cam), "recv": true, "add": true}];
-					if (__allow_audio) {
-						tracks.push({"type": "audio", "capture": __allow_mic, "recv": true, "add": true});
+					let tracks = [{"type": "video", "capture": __allow_cam, "recv": true, "add": true}];
+					if (__allow_audio || __allow_mic) {
+						tracks.push({"type": "audio", "capture": __allow_mic, "recv": __allow_audio, "add": true});
 					}
 					__handle.createAnswer({
 						"jsep": jsep,


### PR DESCRIPTION
Ahoy. I wanted to create a mic passthrough for my PiKVM DIY RPI4 device, was i was missing such a function.
So i added mic support through the browser, creating a virtual mic device through the OTG USB.

Works fine so far!

- Built a custom Raspberry Pi 4 `v2-hdmi` PiKVM image with this KVMD patch and current uStreamer Janus mic support.
- Booted on DIY PiKVM V2 hardware.
- Tested in Teams calls
- Enabled USB UAC2 audio gadget with speakers disabled and mic enabled.
- Confirmed the Web UI can enable browser microphone access without HDMI audio capture.
- Confirmed the target host receives audio through the USB microphone device.

- uStreamer `master` already contains the needed Janus-side mic-only support (`janus: separate audio of mic`, `janus: _aplay_thread(): don't see at has_listeners`).
<img width="1483" height="811" alt="Screenshot From 2026-06-04 14-52-27" src="https://github.com/user-attachments/assets/2c333d2b-621a-4ded-82f4-c6bb880851ca" />
<img width="1483" height="811" alt="Screenshot From 2026-06-04 14-52-15" src="https://github.com/user-attachments/assets/b247530d-7a5b-4eb7-a2c6-3f3909994868" />
<img width="396" height="401" alt="Screenshot From 2026-06-04 14-52-09" src="https://github.com/user-attachments/assets/e8dc5d0b-8e8a-4b40-b547-15283c62c33e" />
<img width="425" height="87" alt="Screenshot From 2026-06-04 15-39-58" src="https://github.com/user-attachments/assets/84cf2909-0ee1-472a-ab17-b1c437c7707f" />

