### PR TITLE
Add Intel AMT plugin based on IPMI plugin using meshcmd

### DIFF
--- a/kvmd/plugins/ugpio/amt.py
+++ b/kvmd/plugins/ugpio/amt.py
@@ -38,10 +38,8 @@ from ...yamlconf import Option
 
 from ...validators import check_string_in_list
 from ...validators.basic import valid_float_f01
-from ...validators.basic import valid_number
 from ...validators.basic import valid_bool
 from ...validators.net import valid_ip_or_host
-from ...validators.net import valid_port
 from ...validators.os import valid_command
 
 from . import GpioDriverOfflineError
@@ -179,13 +177,13 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
     @functools.lru_cache()
     def __make_meshcmd_kwargs(self, action: str) -> dict:
         if action == "status":
-           action_opt = ""
+            action_opt = ""
         else:
-           action_opt = f'--{action}'
+            action_opt = f"--{action}"
         if self.__tls:
-           tls_opt = '--tls'
+            tls_opt = "--tls"
         else:
-           tls_opt = ''
+            tls_opt = ""
         return {
             "cmd": [
                 part.format(

--- a/kvmd/plugins/ugpio/amt.py
+++ b/kvmd/plugins/ugpio/amt.py
@@ -1,0 +1,210 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+import asyncio
+import functools
+
+from typing import Final
+from typing import Callable
+from typing import Any
+
+from ...logging import get_logger
+
+from ... import tools
+from ... import aiotools
+from ... import aioproc
+
+from ...yamlconf import Section
+from ...yamlconf import Option
+
+from ...validators import check_string_in_list
+from ...validators.basic import valid_float_f01
+from ...validators.basic import valid_number
+from ...validators.basic import valid_bool
+from ...validators.net import valid_ip_or_host
+from ...validators.net import valid_port
+from ...validators.os import valid_command
+
+from . import GpioDriverOfflineError
+from . import BaseUserGpioDriver
+
+
+# =====
+_OUTPUTS = {
+    "1": "poweron",
+    "2": "poweroff",
+    "3": "powercycle",
+    "4": "reset",
+    "5": "sleep",
+    "6": "hibernate",
+}
+
+
+# =====
+class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attributes
+    def __init__(  # pylint: disable=super-init-not-called
+        self,
+        instance_name: str,
+        notifier: aiotools.AioNotifier,
+        c: Section,
+    ) -> None:
+
+        super().__init__(instance_name, notifier, c)
+
+        self.__host:   Final[str] = c.host
+        self.__user:   Final[str] = c.user
+        self.__passwd: Final[str] = c.passwd
+        self.__tls:    Final[bool] = c.tls
+
+        self.__passwd_env: Final[str]       = c.passwd_env
+        self.__cmd:        Final[list[str]] = c.cmd
+
+        self.__state_poll: Final[float] = c.state_poll
+
+        self.__online = False
+        self.__power = False
+
+    @classmethod
+    def get_plugin_options(cls) -> dict:
+        return {
+            "host":   Option("",  type=valid_ip_or_host),
+            "user":   Option(""),
+            "passwd": Option(""),
+            "tls":    Option(True, type=valid_bool),
+
+            "passwd_env": Option("AMT_PASSWORD"),
+            "cmd": Option([
+                "/usr/bin/meshcmd",
+                "amtpower",
+                "{action_opt}",
+                "--host", "{host}",
+                "--user", "{user}",
+                "--pass", "{passwd}",
+                "{tls_opt}",
+            ], type=valid_command),
+
+            "state_poll": Option(1.0, type=valid_float_f01),
+        }
+
+    @classmethod
+    def get_pin_validator(cls) -> Callable[[Any], Any]:
+        actions = ["0", *_OUTPUTS, "status", *_OUTPUTS.values()]
+        return (lambda arg: check_string_in_list(arg, "Current power state", actions))
+
+    def register_input(self, pin: str, debounce: float) -> None:
+        _ = debounce
+        if pin not in ["0", "status"]:
+            raise RuntimeError(f"Unsupported mode 'input' for pin={pin} on {self}")
+
+    def register_output(self, pin: str, initial: (bool | None)) -> None:
+        _ = initial
+        if pin not in [*_OUTPUTS, *_OUTPUTS.values()]:
+            raise RuntimeError(f"Unsupported mode 'output' for pin={pin} on {self}")
+
+    async def prepare(self) -> None:
+        get_logger(0).info("Probing driver %s on %s ...", self, self.__host)
+
+    async def run(self) -> None:
+        prev = (False, False)
+        while True:
+            await self.__update_power()
+            new = (self.__online, self.__power)
+            if new != prev:
+                self._notifier.notify()
+                prev = new
+            await asyncio.sleep(self.__state_poll)
+
+    async def read(self, pin: str) -> bool:
+        if not self.__online:
+            raise GpioDriverOfflineError(self)
+        if pin == "0":
+            return self.__power
+        return False
+
+    async def write(self, pin: str, state: bool) -> None:
+        if not self.__online:
+            raise GpioDriverOfflineError(self)
+        if not state:
+            return
+        action = (_OUTPUTS[pin] if pin.isdigit() else pin)
+        try:
+            proc = await aioproc.log_process(**self.__make_meshcmd_kwargs(action), logger=get_logger(0), prefix=str(self))
+            if proc.returncode != 0:
+                raise RuntimeError(f"meshcmd error: retcode={proc.returncode}")
+        except Exception as ex:
+            get_logger(0).error("Can't send AMT power-%s request to %s: %s",
+                                action, self.__host, tools.efmt(ex))
+            raise GpioDriverOfflineError(self)
+
+    # =====
+
+    async def __update_power(self) -> None:
+        try:
+            (proc, text) = await aioproc.read_process(**self.__make_meshcmd_kwargs("status"))
+            if proc.returncode != 0:
+                raise RuntimeError(f"meshcmd error: retcode={proc.returncode}")
+            stripped = text.strip()
+            if stripped.startswith("Current power state: "):
+                self.__power = (stripped == "Current power state: Power on")
+                self.__online = True
+                return
+            if stripped.startswith("Error"):
+                raise RuntimeError(f"Error meshcmd response: {text}")
+            raise RuntimeError(f"Invalid meshcmd response: {text}")
+        except Exception as ex:
+            get_logger(0).error("Can't fetch AMT power status from %s: %s",
+                                self.__host, tools.efmt(ex))
+            self.__power = False
+            self.__online = False
+
+    @functools.lru_cache()
+    def __make_meshcmd_kwargs(self, action: str) -> dict:
+        if action == "status":
+           action_opt = ""
+        else:
+           action_opt = f'--{action}'
+        if self.__tls:
+           tls_opt = '--tls'
+        else:
+           tls_opt = ''
+        return {
+            "cmd": [
+                part.format(
+                    host=self.__host,
+                    user=self.__user,
+                    passwd=self.__passwd,
+                    action_opt=action_opt,
+                    tls_opt=tls_opt,
+                )
+                for part in self.__cmd
+            ],
+            "env": (
+                {self.__passwd_env: self.__passwd}
+                if self.__passwd and self.__passwd_env
+                else None
+            ),
+        }
+
+    def __str__(self) -> str:
+        return f"AMT({self._instance_name})"
+
+    __repr__ = __str__


### PR DESCRIPTION
Hi! Thank you for sharing this amazing product.
I'm a big fan of PiKVM. I love its great UX and expandability.

To support the intel AMT, I've written a plugin as a small patch to the IPMI plugin, using [meshcmd](https://docs.meshcentral.com/meshcmd/).
I tested it with the meshcmd binary downloaded from [here](https://meshcentral.com/executables/meshcmd-linux-arm-64). ([Download page](https://meshcentral.com/downloads.html))
The pin number definition is fixed, just like the IPMI plugin.
Please see my sample override.yaml below.

![screen shot of gpio menu](https://i.imgur.com/OowLMhq.png)

- override.yaml
```yaml
kvmd:
    gpio:
        drivers:
            amt_lenovo1:
                type: amt
                host: 192.168.123.45
                user: admin
                passwd: "(PASSWORD)"
                tls: true
#               state_poll: 3.0   # default: 1.0 sec
        scheme:
            lenovo1_status:
                driver: amt_lenovo1
                pin: 0
                mode: input
            lenovo1_on:
                driver: amt_lenovo1
                pin: 1
                mode: output
                switch: false
            lenovo1_off:
                driver: amt_lenovo1
                pin: 2
                mode: output
                switch: false
            lenovo1_cycle:
                driver: amt_lenovo1
                pin: 3
                mode: output
                switch: false
            lenovo1_reset:
                driver: amt_lenovo1
                pin: 4
                mode: output
                switch: false
            lenovo1_sleep:
                driver: amt_lenovo1
                pin: 5
                mode: output
                switch: false
            lenovo1_hibernate:
                driver: amt_lenovo1
                pin: 6
                mode: output
                switch: false
        view:
            table:
                - ["lenovo1_status", "#lenovo1",  "lenovo1_on|On", "lenovo1_off|confirm|Off", "lenovo1_cycle|confirm|Cycle", "lenovo1_reset|confirm|Reset", "lenovo1_sleep|confirm|Sleep", "lenovo1_hibernate|confirm|Hibernate"]
```

- meshcmd amtpower (called command under the hood)
```txt
[root@pikvm kvmd]# meshcmd help amtpower
AmtPower will get current pwoer state or send a reboot command to a remote Intel AMT device. Example usage:

  meshcmd amtpower --reset --host 1.2.3.4 --user admin --pass mypassword --tls

Required arguments:

  --host [hostname]      The IP address or DNS name of Intel AMT.
  --pass [password]      The Intel AMT login password.

Optional arguments:

  --reset, --poweron, --poweroff, --powercycle, --sleep, --hibernate
  --user [username]                                    The Intel AMT login username, admin is default.
  --tls                                                Specifies that TLS must be used.
  --bootdevice [pxe|hdd|cd|ider-floppy|ider-cdrom]     Specifies the boot device to use after reset, poweron or po          wercycle.
  --bootindex [number]                                 Specifies the index of boot device to use.
```

- diff from ipmi plugin
```diff
--- ipmi.py     2026-06-07 15:46:54.000000000 +0000
+++ amt.py      2026-06-12 11:39:18.883287302 +0000
@@ -39,6 +39,7 @@
 from ...validators import check_string_in_list
 from ...validators.basic import valid_float_f01
 from ...validators.basic import valid_number
+from ...validators.basic import valid_bool
 from ...validators.net import valid_ip_or_host
 from ...validators.net import valid_port
 from ...validators.os import valid_command
@@ -49,12 +50,12 @@

 # =====
 _OUTPUTS = {
-    "1": "on",
-    "2": "off",
-    "3": "cycle",
+    "1": "poweron",
+    "2": "poweroff",
+    "3": "powercycle",
     "4": "reset",
-    "5": "diag",
-    "6": "soft",
+    "5": "sleep",
+    "6": "hibernate",
 }


@@ -70,10 +71,9 @@
         super().__init__(instance_name, notifier, c)

         self.__host:   Final[str] = c.host
-        self.__port:   Final[int] = c.port
-        self.__cipher: Final[int] = c.cipher
         self.__user:   Final[str] = c.user
         self.__passwd: Final[str] = c.passwd
+        self.__tls:    Final[bool] = c.tls

         self.__passwd_env: Final[str]       = c.passwd_env
         self.__cmd:        Final[list[str]] = c.cmd
@@ -87,19 +87,19 @@
     def get_plugin_options(cls) -> dict:
         return {
             "host":   Option("",  type=valid_ip_or_host),
-            "port":   Option(623, type=valid_port),
-            "cipher": Option(17,  type=valid_number.mk(min=0, max=19)),
             "user":   Option(""),
             "passwd": Option(""),
+            "tls":    Option(True, type=valid_bool),

-            "passwd_env": Option("IPMI_PASSWORD"),
+            "passwd_env": Option("AMT_PASSWORD"),
             "cmd": Option([
-                "/usr/bin/ipmitool",
-                "-I", "lanplus",
-                "-C", "{cipher}",
-                "-U", "{user}", "-E",
-                "-H", "{host}", "-p", "{port}",
-                "power", "{action}",
+                "/usr/bin/meshcmd",
+                "amtpower",
+                "{action_opt}",
+                "--host", "{host}",
+                "--user", "{user}",
+                "--pass", "{passwd}",
+                "{tls_opt}",
             ], type=valid_command),

             "state_poll": Option(1.0, type=valid_float_f01),
@@ -108,7 +108,7 @@
     @classmethod
     def get_pin_validator(cls) -> Callable[[Any], Any]:
         actions = ["0", *_OUTPUTS, "status", *_OUTPUTS.values()]
-        return (lambda arg: check_string_in_list(arg, "IPMI action", actions))
+        return (lambda arg: check_string_in_list(arg, "Current power state", actions))

     def register_input(self, pin: str, debounce: float) -> None:
         _ = debounce
@@ -121,7 +121,7 @@
             raise RuntimeError(f"Unsupported mode 'output' for pin={pin} on {self}")

     async def prepare(self) -> None:
-        get_logger(0).info("Probing driver %s on %s:%d ...", self, self.__host, self.__port)
+        get_logger(0).info("Probing driver %s on %s ...", self, self.__host)

     async def run(self) -> None:
         prev = (False, False)
@@ -147,44 +147,54 @@
             return
         action = (_OUTPUTS[pin] if pin.isdigit() else pin)
         try:
-            proc = await aioproc.log_process(**self.__make_ipmitool_kwargs(action), logger=get_logger(0), prefix=str(self))
+            proc = await aioproc.log_process(**self.__make_meshcmd_kwargs(action), logger=get_logger(0), prefix=str(self))
             if proc.returncode != 0:
-                raise RuntimeError(f"Ipmitool error: retcode={proc.returncode}")
+                raise RuntimeError(f"meshcmd error: retcode={proc.returncode}")
         except Exception as ex:
-            get_logger(0).error("Can't send IPMI power-%s request to %s:%d: %s",
-                                action, self.__host, self.__port, tools.efmt(ex))
+            get_logger(0).error("Can't send AMT power-%s request to %s: %s",
+                                action, self.__host, tools.efmt(ex))
             raise GpioDriverOfflineError(self)

     # =====

     async def __update_power(self) -> None:
         try:
-            (proc, text) = await aioproc.read_process(**self.__make_ipmitool_kwargs("status"))
+            (proc, text) = await aioproc.read_process(**self.__make_meshcmd_kwargs("status"))
+#            (proc, text) = await aioproc.read_process(**self.__make_meshcmd_kwargs("status"), logger=get_logger(0))
             if proc.returncode != 0:
-                raise RuntimeError(f"Ipmitool error: retcode={proc.returncode}")
+                raise RuntimeError(f"meshcmd error: retcode={proc.returncode}")
             stripped = text.strip()
-            if stripped.startswith("Chassis Power is "):
-                self.__power = (stripped != "Chassis Power is off")
+            if stripped.startswith("Current power state: "):
+                self.__power = (stripped == "Current power state: Power on")
                 self.__online = True
                 return
-            raise RuntimeError(f"Invalid ipmitool response: {text}")
+            if stripped.startswith("Error"):
+                raise RuntimeError(f"Error meshcmd response: {text}")
+            raise RuntimeError(f"Invalid meshcmd response: {text}")
         except Exception as ex:
-            get_logger(0).error("Can't fetch IPMI power status from %s:%d: %s",
-                                self.__host, self.__port, tools.efmt(ex))
+            get_logger(0).error("Can't fetch AMT power status from %s: %s",
+                                self.__host, tools.efmt(ex))
             self.__power = False
             self.__online = False

     @functools.lru_cache()
-    def __make_ipmitool_kwargs(self, action: str) -> dict:
+    def __make_meshcmd_kwargs(self, action: str) -> dict:
+        if action == "status":
+           action_opt = ""
+        else:
+           action_opt = f'--{action}'
+        if self.__tls:
+           tls_opt = '--tls'
+        else:
+           tls_opt = ''
         return {
             "cmd": [
                 part.format(
                     host=self.__host,
-                    port=self.__port,
-                    cipher=self.__cipher,
                     user=self.__user,
                     passwd=self.__passwd,
-                    action=action,
+                    action_opt=action_opt,
+                    tls_opt=tls_opt,
                 )
                 for part in self.__cmd
             ],
@@ -196,6 +206,6 @@
         }

     def __str__(self) -> str:
-        return f"IPMI({self._instance_name})"
+        return f"AMT({self._instance_name})"

     __repr__ = __str__
```

p.s.
`meshcmd`'s sleep action does not works well with my environment.
It may require the OS's plugin support or something like that.
