### PR TITLE
keyboard/printer: release modifiers before pressing new ones (fixes pikvm/pikvm#1549)

### DIFF
--- a/kvmd/keyboard/printer.py
+++ b/kvmd/keyboard/printer.py
@@ -95,19 +95,28 @@ def text_to_evdev_keys(  # pylint: disable=too-many-branches
                 # Not supported yet
                 continue
 
-            if mods & SymmapModifiers.SHIFT and not shift:
-                yield (ecodes.KEY_LEFTSHIFT, True)
-                shift = True
-            elif not (mods & SymmapModifiers.SHIFT) and shift:
+            need_shift = bool(mods & SymmapModifiers.SHIFT)
+            need_altgr = bool(mods & SymmapModifiers.ALTGR)
+
+            # Release the modifiers that are no longer needed BEFORE pressing
+            # the new ones. Otherwise, switching between keys with different
+            # modifiers (e.g. AltGr+key followed by Shift+key) briefly holds
+            # both Shift and AltGr at the same time, which produces a wrong
+            # symbol on many layouts and breaks the input.
+            # See https://github.com/pikvm/pikvm/issues/1549
+            if shift and not need_shift:
                 yield (ecodes.KEY_LEFTSHIFT, False)
                 shift = False
-
-            if mods & SymmapModifiers.ALTGR and not altgr:
-                yield (ecodes.KEY_RIGHTALT, True)
-                altgr = True
-            elif not (mods & SymmapModifiers.ALTGR) and altgr:
+            if altgr and not need_altgr:
                 yield (ecodes.KEY_RIGHTALT, False)
                 altgr = False
+
+            if need_shift and not shift:
+                yield (ecodes.KEY_LEFTSHIFT, True)
+                shift = True
+            if need_altgr and not altgr:
+                yield (ecodes.KEY_RIGHTALT, True)
+                altgr = True
 
             yield (key, True)
             yield (key, False)

--- a/testenv/tests/keyboard/test_printer.py
+++ b/testenv/tests/keyboard/test_printer.py
@@ -1,0 +1,81 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+from evdev import ecodes
+
+import pytest
+
+from kvmd.keyboard.keysym import SymmapModifiers
+from kvmd.keyboard.printer import text_to_evdev_keys
+from kvmd.keyboard.printer import _ch_to_keysym  # pylint: disable=protected-access
+
+
+# =====
+# A minimal symmap that mimics the relevant keys of layouts like Swedish:
+#   "}" is typed as AltGr + "0", and the double quote as Shift + "2".
+# See https://github.com/pikvm/pikvm/issues/1549
+_SYMMAP = {
+    _ch_to_keysym("}"): {SymmapModifiers.ALTGR: ecodes.KEY_0},
+    _ch_to_keysym("\""): {SymmapModifiers.SHIFT: ecodes.KEY_2},
+    _ch_to_keysym("a"): {0: ecodes.KEY_A},
+}
+
+
+# =====
+@pytest.mark.parametrize("text", ["}\"", "\"}", "}a\"", "}\"}\"a"])
+def test_ok__printer_no_modifier_overlap(text: str) -> None:
+    # Shift and AltGr must never be held at the same time while switching
+    # between keys, otherwise many layouts produce a wrong symbol.
+    held: set[int] = set()
+    for (key, state) in text_to_evdev_keys(text, _SYMMAP):
+        if state:
+            held.add(key)
+        else:
+            held.discard(key)
+        assert not (ecodes.KEY_LEFTSHIFT in held and ecodes.KEY_RIGHTALT in held)
+    assert len(held) == 0  # Everything must be released at the end
+
+
+def test_ok__printer_release_before_press() -> None:
+    # AltGr must be released before Shift is pressed when going from "}" to the quote.
+    assert list(text_to_evdev_keys("}\"", _SYMMAP)) == [
+        (ecodes.KEY_RIGHTALT, True),
+        (ecodes.KEY_0, True),
+        (ecodes.KEY_0, False),
+        (ecodes.KEY_RIGHTALT, False),
+        (ecodes.KEY_LEFTSHIFT, True),
+        (ecodes.KEY_2, True),
+        (ecodes.KEY_2, False),
+        (ecodes.KEY_LEFTSHIFT, False),
+    ]
+
+
+def test_ok__printer_keeps_shared_modifier_pressed() -> None:
+    # A modifier shared by consecutive characters is kept pressed (not toggled per key).
+    assert list(text_to_evdev_keys("\"\"", _SYMMAP)) == [
+        (ecodes.KEY_LEFTSHIFT, True),
+        (ecodes.KEY_2, True),
+        (ecodes.KEY_2, False),
+        (ecodes.KEY_2, True),
+        (ecodes.KEY_2, False),
+        (ecodes.KEY_LEFTSHIFT, False),
+    ]


### PR DESCRIPTION
## Problem

Fixes pikvm/pikvm#1549.

Pasting/typing text via the Web UI **Text** feature (`POST /hid/print` → `text_to_evdev_keys`) breaks the input when two consecutive characters need *different* modifiers. The classic repro on the Swedish layout is the sequence `}"`:

- `}` = **AltGr** + `0`
- `"` = **Shift** + `2`

After this sequence, all following input produces wrong characters until a modifier key is tapped. The reporter confirmed it on ~20 layouts: `cz, da, de, de-ch, es, fi, fo, fr-ca, fr-ch, hr, hu, is, it, lv, nl, no, pt, pt-br, sl, sv`.

## Root cause

In `text_to_evdev_keys`, the **Shift** modifier block was always handled before the **AltGr** block. When switching from an AltGr-character to a Shift-character, this pressed `KEY_LEFTSHIFT` *before* releasing `KEY_RIGHTALT`, so for one moment **both Shift and AltGr were held at the same time** — which selects a different symbol level on these layouts and corrupts subsequent input.

This matches the `evtest` capture in the issue exactly (`LEFTSHIFT` down emitted before `RIGHTALT` up):

```
RIGHTALT  ↓
KEY_0     ↓ ↑
LEFTSHIFT ↓     <-- pressed while AltGr still held
RIGHTALT  ↑     <-- released too late
KEY_2     ↓ ↑
```

## Fix

Release the modifiers that are no longer needed **before** pressing the newly required ones, so Shift and AltGr are never held simultaneously across a key switch. Modifiers shared by consecutive characters are still kept pressed (the existing optimization is preserved).

Resulting order for `}"`:

```
RIGHTALT  ↓
KEY_0     ↓ ↑
RIGHTALT  ↑     <-- released first
LEFTSHIFT ↓
KEY_2     ↓ ↑
LEFTSHIFT ↑
```

## Tests

Adds `testenv/tests/keyboard/test_printer.py`:

- `test_ok__printer_no_modifier_overlap` — invariant (parametrized over several sequences): Shift and AltGr are never held at once, and everything is released at the end.
- `test_ok__printer_release_before_press` — asserts the exact corrected event order for `}"`.
- `test_ok__printer_keeps_shared_modifier_pressed` — ensures a modifier shared by consecutive characters stays held.

> Note: I could not run the Docker `testenv` (`make tox`) locally — it requires Linux (`evdev`/`libxkbcommon`). The change was validated against the lint configs and via a standalone simulation of the old vs. new ordering. Please run CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)