### PR TITLE
Change Intel AMT driver's meshcmd path to /usr/local/bin

### DIFF
--- a/kvmd/plugins/ugpio/amt.py
+++ b/kvmd/plugins/ugpio/amt.py
@@ -91,7 +91,7 @@ class Plugin(BaseUserGpioDriver):  # pylint: disable=too-many-instance-attribute
 
             "passwd_env": Option("AMT_PASSWORD"),
             "cmd": Option([
-                "/usr/bin/meshcmd",
+                "/usr/local/bin/meshcmd",
                 "amtpower",
                 "{action_opt}",
                 "--host", "{host}",


### PR DESCRIPTION
Addressed [this](https://github.com/pikvm/pikvm/pull/1671#issuecomment-4775652752).
