### PR TITLE
pstrun: restore terminal foreground process group after the child exits

### DIFF
--- a/kvmd/apps/pstrun/__init__.py
+++ b/kvmd/apps/pstrun/__init__.py
@@ -49,6 +49,29 @@ def _preexec() -> None:
             get_logger(0).info("Can't perform tcsetpgrp(0): %s", tools.efmt(ex))
 
 
+def _get_fg_pgrp() -> int:
+    if os.isatty(0):
+        try:
+            return os.tcgetpgrp(0)
+        except Exception as ex:
+            get_logger(0).info("Can't perform tcgetpgrp(0): %s", tools.efmt(ex))
+    return -1
+
+
+def _restore_fg_pgrp(pgrp: int) -> None:
+    # _preexec() puts the child into its own foreground process group via tcsetpgrp().
+    # When the child exits, the controlling terminal still points at that now-dead group,
+    # so any subsequent process that reads stdin (e.g. the second kvmd-pstrun launched by
+    # kvmd-certbot) never receives the user's input. Hand the terminal back to the original
+    # foreground group, exactly like a job-control shell does after a foreground job exits.
+    if pgrp >= 0 and os.isatty(0):
+        signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+        try:
+            os.tcsetpgrp(0, pgrp)
+        except Exception as ex:
+            get_logger(0).info("Can't restore tcsetpgrp(0): %s", tools.efmt(ex))
+
+
 async def _run_process(cmd: list[str], data_path: str) -> asyncio.subprocess.Process:  # pylint: disable=no-member
     # https://stackoverflow.com/questions/58918188/why-is-stdin-not-propagated-to-child-process-of-different-process-group
     if os.isatty(0):
@@ -68,6 +91,7 @@ async def _run_cmd_ws(cmd: list[str], ws: aiohttp.ClientWebSocketResponse) -> in
     recv_task: (asyncio.Task | None) = None
     proc_task: (asyncio.Task | None) = None
     proc: (asyncio.subprocess.Process | None) = None  # pylint: disable=no-member
+    fg_pgrp = -1
 
     try:  # pylint: disable=too-many-nested-blocks
         while True:
@@ -87,6 +111,7 @@ async def _run_cmd_ws(cmd: list[str], ws: aiohttp.ClientWebSocketResponse) -> in
                         if event["data"]["write_allowed"] and proc is None:
                             logger.info("PST write is allowed: %s", event["data"]["path"])
                             logger.info("Running the process ...")
+                            fg_pgrp = _get_fg_pgrp()
                             proc = await _run_process(cmd, event["data"]["path"])
                         elif not event["data"]["write_allowed"]:
                             logger.error("PST write is not allowed")
@@ -110,6 +135,7 @@ async def _run_cmd_ws(cmd: list[str], ws: aiohttp.ClientWebSocketResponse) -> in
         proc_task.cancel()
     if proc is not None:
         await aioproc.kill_process(proc, 1, logger)
+        _restore_fg_pgrp(fg_pgrp)
         assert proc.returncode is not None
         logger.info("Process finished: returncode=%d", proc.returncode)
         return proc.returncode


### PR DESCRIPTION
> ♻️ Reopens #225. Auto-closed when I accidentally deleted my fork; the commit (`50dfcf2`) is unchanged, re-pushed from a fresh fork.

## Problem

Fixes pikvm/pikvm#1467.

`kvmd-pstrun` runs its child in its own **foreground process group** so interactive programs (like `certbot`) can talk to the terminal — `_preexec()` does `os.setpgrp()` followed by `os.tcsetpgrp(0, …)`, mimicking what a job-control shell does for a foreground job:

https://github.com/pikvm/kvmd/blob/master/kvmd/apps/pstrun/__init__.py#L43-L49

But unlike a shell, `kvmd-pstrun` **never hands the terminal back** when the child exits. After the child is gone, the controlling terminal's foreground process group still points at the now-dead child group, so any process that reads stdin afterwards is no longer in the foreground group and never receives user input.

`kvmd-certbot` invokes `kvmd-pstrun` twice — first `ensure_runroot`, then the actual `certbot` run:

https://github.com/pikvm/kvmd/blob/master/scripts/kvmd-certbot#L51-L57
https://github.com/pikvm/kvmd/blob/master/scripts/kvmd-certbot#L99

So the first invocation leaves the terminal in a broken state, and the second invocation's interactive `certbot` prompts (ToS agreement, "keep/renew existing certificate?", etc.) never see the user's keystrokes. The reporter (@gentoo-root) confirmed that forcing the first invocation to skip `tcsetpgrp()` (via `ensure_runroot < /dev/null`) works around it.

## Fix

Capture the terminal's foreground process group just before launching the child, and restore it once the child has finished — exactly the step a job-control shell performs after a foreground job exits. `SIGTTOU` is ignored around the restoring `tcsetpgrp()` (the parent is a background group at that point), consistent with the existing handling in `_run_process()`.

This neutralizes the lingering terminal side effect that the reporter's `< /dev/null` workaround avoids, and also leaves the terminal clean for the `--` passthrough and `renew` code paths, not just `certonly`.

## Notes / testing

The change is minimal and mirrors the existing style in the file. I was not able to run a full end-to-end test of the PiKVM + PST-daemon + `sudo`-to-`kvmd-certbot` + interactive `ssh -t` stack myself; verification here is by static reasoning + syntax compile. Happy to adjust placement (e.g. capture/restore inside `_run_process` instead) if you'd prefer.
