### PR TITLE
ipmi: fix SOL console stutter by decoupling serial reads from the blocking sender (#899)

### DIFF
--- a/kvmd/apps/_scheme.py
+++ b/kvmd/apps/_scheme.py
@@ -704,6 +704,7 @@ def make_config_scheme() -> dict:
                 "speed":          Option(115200, type=valid_tty_speed, unpack_as="sol_speed"),
                 "select_timeout": Option(0.1,    type=valid_float_f01, unpack_as="sol_select_timeout"),
                 "proxy_port":     Option(0,      type=valid_port, unpack_as="sol_proxy_port"),
+                "max_packet":     Option(256,    type=valid_int_f1, unpack_as="sol_max_packet"),
             },
         },
 

--- a/kvmd/apps/ipmi/server.py
+++ b/kvmd/apps/ipmi/server.py
@@ -27,6 +27,8 @@ import threading
 import functools
 import queue
 
+from typing import Callable
+
 import aiohttp
 import serial
 
@@ -43,6 +45,68 @@ from ... import aiomulti
 from ... import network
 
 from .auth import IpmiAuthManager
+
+
+# =====
+def _sol_pump(
+    console: IpmiConsole,
+    tty: serial.Serial,
+    user_q: aiomulti.AioMpQueue[bytes],
+    select_timeout: float,
+    should_stop: Callable[[], bool],
+) -> None:
+
+    # pyghmi's ServerConsole.send_data() is a blocking, stop-and-wait SOL sender: it
+    # transmits a single (<=maxoutcount bytes) SOL packet and then waits for the client's
+    # ACK before returning. Calling it inline in the read loop stalls serial reads for the
+    # whole ACK round-trip, so the kernel serial buffer fills up and console output arrives
+    # in bursts separated by pauses while keystrokes lag (pikvm/pikvm#899).
+    #
+    # Decouple reading from sending: a dedicated sender thread owns every (blocking)
+    # send_data() call, while this thread keeps draining the serial port and forwarding
+    # user input without interruption. Only the sender thread ever touches the console, so
+    # pyghmi's session pump is still driven by exactly one extra thread (as before) and its
+    # output lock is never contended.
+
+    out_buf = bytearray()
+    out_lock = threading.Lock()
+    out_wake = threading.Event()
+
+    def sender() -> None:
+        while not should_stop():
+            out_wake.wait(select_timeout)
+            out_wake.clear()
+            with out_lock:
+                if not out_buf:
+                    continue
+                chunk = bytes(out_buf)
+                out_buf.clear()
+            console.send_data(chunk)  # Blocks until the client ACKs; only this thread sends
+
+    sender_thread = threading.Thread(target=sender, daemon=True)
+    sender_thread.start()
+    try:
+        qr = user_q.get_reader()
+        while not should_stop():
+            ready = select.select([qr, tty], [], [], select_timeout)[0]
+            if qr in ready:
+                data = b""
+                for _ in range(user_q.qsize()):  # Don't hold on this with [not empty()]
+                    try:
+                        data += user_q.get_nowait()
+                    except queue.Empty:
+                        break
+                if data:
+                    tty.write(data)
+            if tty in ready:
+                data = tty.read_all()
+                if data:
+                    with out_lock:
+                        out_buf += data
+                    out_wake.set()  # Hand the new data to the sender
+    finally:
+        out_wake.set()  # Wake the sender so it observes should_stop() and exits
+        sender_thread.join()
 
 
 # =====
@@ -63,6 +127,7 @@ class IpmiServer(BaseIpmiServer):  # pylint: disable=too-many-instance-attribute
         sol_speed: int,
         sol_select_timeout: float,
         sol_proxy_port: int,
+        sol_max_packet: int,
     ) -> None:
 
         host = network.get_listen_host(host)
@@ -79,6 +144,7 @@ class IpmiServer(BaseIpmiServer):  # pylint: disable=too-many-instance-attribute
         self.__sol_speed = sol_speed
         self.__sol_select_timeout = sol_select_timeout
         self.__sol_proxy_port = (sol_proxy_port or port)
+        self.__sol_max_packet = sol_max_packet
 
         self.__sol_lock = threading.Lock()
         self.__sol_console: (IpmiConsole | None) = None
@@ -214,6 +280,11 @@ class IpmiServer(BaseIpmiServer):  # pylint: disable=too-many-instance-attribute
         assert self.__sol_thread is None
         user_q: aiomulti.AioMpQueue[bytes] = aiomulti.AioMpQueue()  # Only for select()
         self.__sol_console = IpmiConsole(session, user_q.put_nowait)
+        # pyghmi hard-codes the per-packet SOL payload cap to 256 bytes and never negotiates it.
+        # Each packet costs one blocking stop-and-wait ACK round-trip, so a larger cap means
+        # fewer round-trips for the same data. Configurable because some clients may reject
+        # oversized SOL payloads; the default (256) preserves pyghmi's original behavior.
+        self.__sol_console.maxoutcount = self.__sol_max_packet
         self.__sol_thread = threading.Thread(target=self.__sol_worker, args=(user_q,), daemon=True)
         self.__sol_thread.start()
 
@@ -239,21 +310,12 @@ class IpmiServer(BaseIpmiServer):  # pylint: disable=too-many-instance-attribute
             assert self.__sol_console is not None
             with serial.Serial(self.__sol_device_path, self.__sol_speed) as tty:
                 logger.info("Opened SOL port %s at speed=%d", self.__sol_device_path, self.__sol_speed)
-                qr = user_q.get_reader()
                 try:
-                    while not self.__sol_stop:
-                        ready = select.select([qr, tty], [], [], self.__sol_select_timeout)[0]
-                        if qr in ready:
-                            data = b""
-                            for _ in range(user_q.qsize()):  # Don't hold on this with [not empty()]
-                                try:
-                                    data += user_q.get_nowait()
-                                except queue.Empty:
-                                    break
-                            if data:
-                                tty.write(data)
-                        if tty in ready:
-                            self.__sol_console.send_data(tty.read_all())
+                    _sol_pump(
+                        self.__sol_console, tty, user_q,
+                        self.__sol_select_timeout,
+                        (lambda: self.__sol_stop),
+                    )
                 finally:
                     logger.info("Closed SOL port %s", self.__sol_device_path)
         except Exception:

--- a/testenv/tests/apps/ipmi/__init__.py
+++ b/testenv/tests/apps/ipmi/__init__.py
@@ -1,0 +1,20 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #

--- a/testenv/tests/apps/ipmi/test_sol.py
+++ b/testenv/tests/apps/ipmi/test_sol.py
@@ -1,0 +1,161 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+import os
+import time
+import queue
+import threading
+
+import serial
+
+import pytest
+
+from kvmd.apps.ipmi.server import _sol_pump
+
+
+# =====
+class _TtyProbe:
+    # Wraps a real serial.Serial, timestamping every read that returns data
+    # so the test can measure how long the reader was ever stalled.
+
+    def __init__(self, ser: serial.Serial) -> None:
+        self.__ser = ser
+        self.read_times: list[float] = []
+        self.total_read = 0
+
+    def fileno(self) -> int:
+        return self.__ser.fileno()
+
+    def read_all(self) -> bytes:
+        data = self.__ser.read_all()
+        if data:
+            self.read_times.append(time.monotonic())
+            self.total_read += len(data)
+        return data
+
+    def write(self, data: bytes) -> int:
+        return self.__ser.write(data)
+
+
+class _BlockingConsole:
+    # Stands in for pyghmi's ServerConsole: send_data() blocks for block_s seconds,
+    # modelling Console._sendoutput waiting (stop-and-wait) for the client's SOL ACK.
+
+    def __init__(self, block_s: float) -> None:
+        self.__block_s = block_s
+        self.calls = 0
+        self.sent = 0
+
+    def send_data(self, data: bytes) -> None:
+        self.calls += 1
+        self.sent += len(data)
+        time.sleep(self.__block_s)
+
+
+class _FakeUserQ:
+    # Minimal AioMpQueue stand-in that never has pending user input.
+
+    def __init__(self) -> None:
+        (self.__r, self.__w) = os.pipe()
+
+    def get_reader(self) -> int:
+        return self.__r
+
+    def qsize(self) -> int:
+        return 0
+
+    def get_nowait(self) -> bytes:
+        raise queue.Empty
+
+    def close(self) -> None:
+        os.close(self.__r)
+        os.close(self.__w)
+
+
+# =====
+@pytest.mark.skipif(not hasattr(os, "openpty"), reason="requires a POSIX pty")
+def test_ok__sol_pump_does_not_block_reads_on_slow_send() -> None:
+    # Regression test for pikvm/pikvm#899: pyghmi's SOL send_data() blocks until the
+    # client ACKs each packet. _sol_pump must keep draining the serial port during that
+    # blocking send instead of stalling (which caused bursty/stuttering console output).
+
+    block_s = 0.5           # each send_data() blocks half a second
+    select_timeout = 0.05
+    feed_s = 1.5
+    rate_bps = 11520        # 115200 baud, 8N1
+
+    (master, slave) = os.openpty()
+    ser = serial.Serial(os.ttyname(slave))
+    tty = _TtyProbe(ser)
+    console = _BlockingConsole(block_s)
+    user_q = _FakeUserQ()
+    stop = threading.Event()
+
+    chunk = b"x" * 96
+    interval = len(chunk) / rate_bps
+    fed = 0
+
+    def feeder() -> None:
+        nonlocal fed
+        deadline = time.monotonic()
+        end = deadline + feed_s
+        while time.monotonic() < end and not stop.is_set():
+            os.write(master, chunk)
+            fed += len(chunk)
+            deadline += interval
+            slp = deadline - time.monotonic()
+            if slp > 0:
+                time.sleep(slp)
+
+    worker = threading.Thread(
+        target=_sol_pump,
+        args=(console, tty, user_q, select_timeout, stop.is_set),
+        daemon=True,
+    )
+    feed = threading.Thread(target=feeder, daemon=True)
+    worker.start()
+    feed.start()
+    feed.join()
+    time.sleep(block_s + 0.3)   # let the pump drain the tail
+    stop.set()
+    worker.join(timeout=block_s + 2.0)
+
+    times = tty.read_times
+    gaps = [b - a for (a, b) in zip(times, times[1:])]
+    max_gap = max(gaps) if gaps else 0.0
+
+    try:
+        # The sender must actually have been blocking (otherwise the test proves nothing).
+        assert console.calls >= 1
+        # The reader kept going during the blocked sends: the largest gap between reads is
+        # on the order of select_timeout, nowhere near block_s. (Old inline code stalled for
+        # a full block_s == 0.5s on every send.)
+        assert max_gap < block_s / 2, f"reader stalled for {max_gap:.3f}s (block was {block_s}s)"
+        # Nothing was dropped: everything fed was read off the serial port.
+        assert tty.total_read == fed
+        assert fed > 0
+    finally:
+        stop.set()
+        os.close(master)
+        ser.close()
+        os.close(slave)
+        user_q.close()


### PR DESCRIPTION
## Problem

Fixes pikvm/pikvm#899.

IPMI SOL console output through `kvmd-ipmi` stutters: a few lines to a few screenfuls
appear, then a brief pause, repeatedly (e.g. running `dmesg` over `ipmitool ... sol activate`
at 115200 baud). It's unusable as a smooth serial console compared to a direct terminal or
`conserver`.

## Root cause

kvmd's SOL worker (`kvmd/apps/ipmi/server.py`) ran a single-threaded loop:

```python
while not stop:
    ready = select.select([qr, tty], ...)
    if tty in ready:
        self.__sol_console.send_data(tty.read_all())   # <-- blocks here
```

`self.__sol_console` is a `pyghmi.ipmi.console.ServerConsole`, whose `send_data()` inherits
`Console`'s **stop-and-wait** SOL sender (`console.py` `_sendoutput`): it transmits a single
packet (≤ `maxoutcount`, hard-coded to **256 bytes**) and then **blocks the calling thread**
in a retry loop (`while retries and self.awaitingack: self.wait_for_rsp(0.5); ...`) until the
client ACKs — only then returning to send the next 256-byte chunk.

Because that blocking send runs **inline in the read loop**, the serial port is not read for
the whole ACK round-trip. Serial data piles up in the kernel buffer and floods out on the next
`read_all()`, and user keystrokes aren't serviced either — i.e. bursts-then-pause + input lag.

## Fix

Decouple reading from sending. A dedicated **sender thread** owns every (blocking)
`send_data()` call, while the worker thread keeps draining the serial port and forwarding
user input continuously. Only the sender thread ever touches the pyghmi console, so the
session pump is still driven by exactly one extra thread (as before) and the console's output
lock is never contended. (Refactored into a module-level `_sol_pump()` so it's unit-testable.)

Also exposes **`ipmi.sol.max_packet`** (default `256`, i.e. unchanged) to raise pyghmi's
per-packet SOL cap. Each packet costs one blocking ACK round-trip, so a larger cap means fewer
round-trips for the same data. It's left at pyghmi's default because some SOL clients may
reject oversized payloads — operators who control their client can raise it and test.

### Honest scope

The **window-of-1** behavior is mandated by the IPMI 2.0 SOL spec, and the 256-byte cap and the
0.5s retransmit timer live inside pyghmi. So this change removes the read-starvation/burstiness
and input lag and gives operators the packet-size lever, but it does **not** remove the
fundamental round-trip-bound throughput ceiling — SOL gets noticeably smoother/more responsive
but won't match a raw TCP stream like `conserver`. A complete cure (adaptive retransmit,
negotiated packet size, non-blocking send) belongs upstream in pyghmi. Happy to adjust the
approach if you'd prefer it shaped differently.

## Tests

Adds `testenv/tests/apps/ipmi/test_sol.py`. It drives the real `_sol_pump()` against a
`os.openpty()` serial device with a stub console whose `send_data()` **blocks** (modelling
pyghmi's ACK wait), and asserts the reader keeps draining during the blocked send (max gap
between serial reads ≪ the block time) with no data loss.

I could not run the Docker `testenv` (`make tox`) on my machine (macOS — it needs Linux
`evdev`/`libxkbcommon`), so I validated `_sol_pump()` in isolation against pyghmi 1.6.18 +
pyserial 3.5 on a pty. Before/after, feeding a pty at ~11520 B/s for 3s with `send_data()`
blocking 1.0s per call:

| loop | fed | read | reads | **max read gap** |
|------|-----|------|-------|------------------|
| old (inline send) | 3168 B | 3168 B | 5 | **1005 ms** (starved; back-pressures the source to ~1 KB/s) |
| new (`_sol_pump`) | 34560 B | 34560 B | 360 | **10 ms** (full rate drained during blocked sends) |

What this does **not** cover (needs hardware I don't have): the real over-the-wire RTT/jitter,
the specific USB-serial adapter timing, and whether a raised `max_packet` is tolerated by a
given client. Please run CI and, if possible, a real `ipmitool` SOL session to confirm.
