### PR TITLE
pstrun: perform minimal job control

### DIFF
--- a/kvmd/apps/pstrun/__init__.py
+++ b/kvmd/apps/pstrun/__init__.py
@@ -25,6 +25,10 @@ import signal
 import asyncio
 import asyncio.subprocess
 import argparse
+import contextlib
+import copy
+import dataclasses
+import termios
 
 import aiohttp
 
@@ -40,20 +44,98 @@ from .. import init
 
 
 # =====
-def _preexec() -> None:
-    os.setpgrp()
-    if os.isatty(0):
-        try:
-            os.tcsetpgrp(0, os.getpgid(0))
-        except Exception as ex:
-            get_logger(0).info("Can't perform tcsetpgrp(0): %s", tools.efmt(ex))
+if not hasattr(termios, '_POSIX_VDISABLE'):
+    raise RuntimeError("termios._POSIX_VDISABLE is not available")
 
 
+# =====
+@dataclasses.dataclass
+class _Termios:
+    """Fields of struct termios, in the order of the pseudo-tuple returned by termios.tcgetattr()"""
+    iflag: int
+    oflag: int
+    cflag: int
+    lflag: int
+    ispeed: int
+    ospeed: int
+    cc: list[int]
+
+    def fields(self) -> list[int | list[int]]:
+        # shallow equivalent of dataclasses.astuple()
+        return [
+            getattr(self, field.name)
+            for field in dataclasses.fields(self)
+        ]
+
+
+# =====
+KBD_SIGNALS = (
+    signal.SIGINT,  # ^C
+    signal.SIGQUIT,  # ^\
+)
+TTY_SIGNALS = (
+    signal.SIGTTOU,
+    signal.SIGTTIN,
+)
+
+g_ctty_fd = None
+g_is_interactive = None
+g_termios: _Termios | None = None
+
+
+# =====
 async def _run_process(cmd: list[str], data_path: str) -> asyncio.subprocess.Process:  # pylint: disable=no-member
+    """
+    Starts a potentially interactive process, performing minimal job control
+    if we are launched in an interactive context.
+    """
+    # Assorted references:
     # https://stackoverflow.com/questions/58918188/why-is-stdin-not-propagated-to-child-process-of-different-process-group
-    if os.isatty(0):
-        signal.signal(signal.SIGTTOU, signal.SIG_IGN)
-    return (await asyncio.create_subprocess_exec(
+
+    global g_ctty_fd, g_is_interactive, g_termios
+
+    # locate our controlling terminal
+    try:
+        g_ctty_fd = os.open("/dev/tty", os.O_RDWR | os.O_NOCTTY)
+        # only perform job control if we are in the foreground group
+        g_is_interactive = os.tcgetpgrp(g_ctty_fd) == os.getpgid(0)
+    except OSError:
+        g_ctty_fd = None
+        g_is_interactive = False
+
+    # ignore keyboard signals such that we stay alive through setup and teardown
+    if g_ctty_fd is not None:
+        for s in KBD_SIGNALS:
+            signal.signal(s, signal.SIG_IGN)
+
+    if g_is_interactive:
+        assert g_ctty_fd is not None
+        # ignore terminal signals such that our own tcset*() on cleanup
+        # will not signal us when we are not in a foreground group anymore
+        for s in TTY_SIGNALS:
+            signal.signal(s, signal.SIG_IGN)
+
+        # configure terminal for the child
+        # (suppress ^Z as we are not doing full, proper job control)
+        g_termios = _Termios(*termios.tcgetattr(g_ctty_fd))
+        ti = copy.deepcopy(g_termios)
+        ti.cc[termios.VSUSP] = termios._POSIX_VDISABLE  # type: ignore[attr-defined]
+        termios.tcsetattr(g_ctty_fd, termios.TCSANOW, ti.fields())
+
+    def _preexec() -> None:
+        if g_is_interactive:
+            assert g_ctty_fd is not None
+            # place ourselves into a new process group and become foreground
+            me = os.getpid()
+            os.setpgid(me, me)
+            os.tcsetpgrp(g_ctty_fd, me)
+        # reset signal disposition for the child
+        # "The dispositions of any signals that are being caught are reset to the default",
+        # which notably does not include SIG_IGN
+        for s in KBD_SIGNALS + TTY_SIGNALS:
+            signal.signal(s, signal.SIG_DFL)
+
+    subprocess = (await asyncio.create_subprocess_exec(
         *cmd,
         preexec_fn=_preexec,
         env={
@@ -61,6 +143,26 @@ async def _run_process(cmd: list[str], data_path: str) -> asyncio.subprocess.Pro
             "KVMD_PST_DATA": data_path,
         },
     ))
+
+    child = subprocess.pid
+    if g_is_interactive:
+        assert g_ctty_fd is not None
+        # race avoidance: place the child into a new process group and make it foreground
+        with contextlib.suppress(PermissionError):
+            # setpgid() returns EACCES if we lost the race and the child had exec'd already
+            os.setpgid(child, child)
+        os.tcsetpgrp(g_ctty_fd, child)
+
+    return subprocess
+
+
+def _cleanup_process():
+    global g_ctty_fd, g_is_interactive, g_termios
+    if g_is_interactive:
+        assert g_ctty_fd is not None
+        assert g_termios is not None
+        os.tcsetpgrp(g_ctty_fd, os.getpgrp())
+        termios.tcsetattr(g_ctty_fd, termios.TCSANOW, g_termios.fields())
 
 
 async def _run_cmd_ws(cmd: list[str], ws: aiohttp.ClientWebSocketResponse) -> int:  # pylint: disable=too-many-branches
@@ -109,6 +211,7 @@ async def _run_cmd_ws(cmd: list[str], ws: aiohttp.ClientWebSocketResponse) -> in
     if proc_task is not None:
         proc_task.cancel()
     if proc is not None:
+        _cleanup_process()
         await aioproc.kill_process(proc, 1, logger)
         assert proc.returncode is not None
         logger.info("Process finished: returncode=%d", proc.returncode)


### PR DESCRIPTION
`kvmd-pstrun` places the child in its own foreground process group to become immune to keyboard signals and route them to the child instead.

However, it does not restore the foreground process group of the controlling terminal once the child exits, breaking subsequent ctty operations in absence of an interactive job-controlling shell between `kvmd-pstrun` invocations (which would sanitize the terminal).

Implement minimal correct job control, predicated on the wrapper itself being in foreground of a controlling terminal. Additionally, suppress ^Z for the duration of the child (as we do not implement *full* job control) and ignore keyboard signals to avoid being interrupted mid-cleanup.

Fixes: pikvm/pikvm#1467
Suggested-by: Mohammed Awad \<mawad10101@gmail.com\>
See-also: 50dfcf2d ("pstrun: restore terminal foreground process group after the child exits")
See-also: #228