### PR TITLE
hid: support consumer control devices

### DIFF
--- a/configs/os/udev/v2-hdmi-rpi3.rules
+++ b/configs/os/udev/v2-hdmi-rpi3.rules
@@ -4,3 +4,4 @@ KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", KERNELS=="3f801000.csi|3f801000
 KERNEL=="hidg0", GROUP="kvmd", SYMLINK+="kvmd-hid-keyboard"
 KERNEL=="hidg1", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse"
 KERNEL=="hidg2", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse-alt"
+KERNEL=="hidg3", GROUP="kvmd", SYMLINK+="kvmd-hid-consumer"

--- a/configs/os/udev/v2-hdmi-rpi4.rules
+++ b/configs/os/udev/v2-hdmi-rpi4.rules
@@ -4,3 +4,4 @@ KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", KERNELS=="fe801000.csi|fe801000
 KERNEL=="hidg0", GROUP="kvmd", SYMLINK+="kvmd-hid-keyboard"
 KERNEL=="hidg1", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse"
 KERNEL=="hidg2", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse-alt"
+KERNEL=="hidg3", GROUP="kvmd", SYMLINK+="kvmd-hid-consumer"

--- a/configs/os/udev/v2-hdmi-zero2w.rules
+++ b/configs/os/udev/v2-hdmi-zero2w.rules
@@ -4,3 +4,4 @@ KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", KERNELS=="3f801000.csi|3f801000
 KERNEL=="hidg0", GROUP="kvmd", SYMLINK+="kvmd-hid-keyboard"
 KERNEL=="hidg1", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse"
 KERNEL=="hidg2", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse-alt"
+KERNEL=="hidg3", GROUP="kvmd", SYMLINK+="kvmd-hid-consumer"

--- a/configs/os/udev/v2-hdmiusb-rpi4.rules
+++ b/configs/os/udev/v2-hdmiusb-rpi4.rules
@@ -4,3 +4,4 @@ KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", ATTRS{bInterfaceNumber}=="?*", 
 KERNEL=="hidg0", GROUP="kvmd", SYMLINK+="kvmd-hid-keyboard"
 KERNEL=="hidg1", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse"
 KERNEL=="hidg2", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse-alt"
+KERNEL=="hidg3", GROUP="kvmd", SYMLINK+="kvmd-hid-consumer"

--- a/configs/os/udev/v3-hdmi-rpi4.rules
+++ b/configs/os/udev/v3-hdmi-rpi4.rules
@@ -4,3 +4,4 @@ KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", KERNELS=="fe801000.csi|fe801000
 KERNEL=="hidg0", GROUP="kvmd", SYMLINK+="kvmd-hid-keyboard"
 KERNEL=="hidg1", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse"
 KERNEL=="hidg2", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse-alt"
+KERNEL=="hidg3", GROUP="kvmd", SYMLINK+="kvmd-hid-consumer"

--- a/configs/os/udev/v4mini-hdmi-rpi4.rules
+++ b/configs/os/udev/v4mini-hdmi-rpi4.rules
@@ -4,3 +4,4 @@ KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", KERNELS=="fe801000.csi|fe801000
 KERNEL=="hidg0", GROUP="kvmd", SYMLINK+="kvmd-hid-keyboard"
 KERNEL=="hidg1", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse"
 KERNEL=="hidg2", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse-alt"
+KERNEL=="hidg3", GROUP="kvmd", SYMLINK+="kvmd-hid-consumer"

--- a/configs/os/udev/v4plus-hdmi-rpi4.rules
+++ b/configs/os/udev/v4plus-hdmi-rpi4.rules
@@ -4,4 +4,5 @@ KERNEL=="video[0-9]*", SUBSYSTEM=="video4linux", KERNELS=="fe801000.csi|fe801000
 KERNEL=="hidg0", GROUP="kvmd", SYMLINK+="kvmd-hid-keyboard"
 KERNEL=="hidg1", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse"
 KERNEL=="hidg2", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse-alt"
+KERNEL=="hidg3", GROUP="kvmd", SYMLINK+="kvmd-hid-consumer"
 SUBSYSTEM=="drm", ACTION=="change", ENV{DEVLINKS}=="/dev/dri/by-path/platform-gpu-card", RUN+="/usr/lib/kvmd/kvmd-udev-restart-pass %k %E{CONNECTOR}"

--- a/kvmd/apps/_scheme.py
+++ b/kvmd/apps/_scheme.py
@@ -532,6 +532,9 @@ def make_config_scheme() -> dict:
                     "mouse": {
                         "start": Option(True, type=valid_bool),
                     },
+                    "consumer": {
+                        "start": Option(False, type=valid_bool),
+                    },
                     "mouse_alt": {
                         "start": Option(True, type=valid_bool),
                     },

--- a/kvmd/apps/localhid/hid.py
+++ b/kvmd/apps/localhid/hid.py
@@ -30,6 +30,14 @@ from evdev import ecodes
 
 
 # =====
+_CONSUMER_KEYS: Final[frozenset[int]] = frozenset({
+    ecodes.KEY_MUTE,
+    ecodes.KEY_VOLUMEUP,
+    ecodes.KEY_VOLUMEDOWN,
+})
+
+
+# =====
 class Hid:  # pylint: disable=too-many-instance-attributes
     KEY:          Final[int] = 0
     MOUSE_BUTTON: Final[int] = 1
@@ -56,6 +64,7 @@ class Hid:  # pylint: disable=too-many-instance-attributes
             or ecodes.KEY_LEFTSHIFT in keys
             or ecodes.KEY_RIGHTSHIFT in keys
         )
+        self.__has_consumer = bool(_CONSUMER_KEYS.intersection(keys))
 
         rels = caps.get(ecodes.EV_REL, [])
         self.__has_mouse_rel = (
@@ -66,7 +75,7 @@ class Hid:  # pylint: disable=too-many-instance-attributes
         self.__grabbed = False
 
     def is_suitable(self) -> bool:
-        return (self.__has_keyboard or self.__has_mouse_rel)
+        return (self.__has_keyboard or self.__has_consumer or self.__has_mouse_rel)
 
     def set_leds(self, caps: bool, scroll: bool, num: bool) -> None:
         if self.__grabbed:
@@ -98,7 +107,7 @@ class Hid:  # pylint: disable=too-many-instance-attributes
             if not self.__grabbed:
                 # Клавиши перехватываются всегда для обработки хоткеев,
                 # всё остальное пропускается для экономии ресурсов.
-                if event.type == ecodes.EV_KEY and event.value != 2 and (event.code in ecodes.KEY):
+                if event.type == ecodes.EV_KEY and event.value != 2 and self.__is_key_allowed(event.code):
                     put(self.KEY, (event.code, bool(event.value)))
                 continue
 
@@ -124,10 +133,16 @@ class Hid:  # pylint: disable=too-many-instance-attributes
                     wheel_x = wheel_y = 0
 
             elif event.type == ecodes.EV_KEY and event.value != 2:
-                if event.code in ecodes.KEY:
+                if self.__is_key_allowed(event.code):
                     put(self.KEY, (event.code, bool(event.value)))
                 elif event.code in ecodes.BTN:
                     put(self.MOUSE_BUTTON, (event.code, bool(event.value)))
+
+    def __is_key_allowed(self, code: int) -> bool:
+        return (
+            code in ecodes.KEY
+            and (self.__has_keyboard or self.__has_mouse_rel or code in _CONSUMER_KEYS)
+        )
 
     def __splitted_deltas(self, delta_x: int, delta_y: int) -> Generator[tuple[int, int]]:
         sign_x = (-1 if delta_x < 0 else 1)
@@ -147,6 +162,8 @@ class Hid:  # pylint: disable=too-many-instance-attributes
             info.append("syn")
         if self.__has_keyboard:
             info.append("keyboard")
+        if self.__has_consumer:
+            info.append("consumer")
         if self.__has_mouse_rel:
             info.append("mouse_rel")
         return f"Hid({self.__device.path!r}, {self.__device.name!r}, {self.__device.phys!r}, {', '.join(info)})"

--- a/kvmd/apps/otg/__init__.py
+++ b/kvmd/apps/otg/__init__.py
@@ -44,6 +44,7 @@ from ... import usb
 from .. import init
 
 from .hid import Hid
+from .hid.consumer import make_consumer_hid
 from .hid.keyboard import make_keyboard_hid
 from .hid.mouse import make_mouse_hid
 
@@ -256,6 +257,9 @@ class _GadgetConfig:
     def add_keyboard(self, starter: list[str], start: bool, remote_wakeup: bool) -> None:
         self.__add_hid("Keyboard", starter, start, remote_wakeup, make_keyboard_hid())
 
+    def add_consumer(self, starter: list[str], start: bool, remote_wakeup: bool) -> None:
+        self.__add_hid("Consumer Control", starter, start, remote_wakeup, make_consumer_hid())
+
     def add_mouse(self, starter: list[str], start: bool, remote_wakeup: bool, absolute: bool, horizontal_wheel: bool) -> None:
         desc = ("Absolute" if absolute else "Relative") + " Mouse"
         self.__add_hid(desc, starter, start, remote_wakeup, make_mouse_hid(absolute, horizontal_wheel))
@@ -412,10 +416,13 @@ def _cmd_start(config: Section) -> None:  # pylint: disable=too-many-statements,
         ckhm = config.kvmd.hid.mouse
         gc.add_mouse(["hid", "mouse"], cod.hid.mouse.start,
                      config.otg.remote_wakeup, ckhm.absolute, ckhm.horizontal_wheel)
-        if config.kvmd.hid.mouse_alt.device:
-            logger.info("===== HID-Mouse-Alt =====")
-            gc.add_mouse(["hid", "mouse_alt"], cod.hid.mouse_alt.start,
-                         config.otg.remote_wakeup, (not ckhm.absolute), ckhm.horizontal_wheel)
+        # Reserve the established hidg2 minor even when the alternate mouse is
+        # disabled. An inactive function consumes no endpoint and keeps any
+        # later HID function on a stable device node.
+        logger.info("===== HID-Mouse-Alt =====")
+        gc.add_mouse(["hid", "mouse_alt"],
+                     (bool(config.kvmd.hid.mouse_alt.device) and cod.hid.mouse_alt.start),
+                     config.otg.remote_wakeup, (not ckhm.absolute), ckhm.horizontal_wheel)
 
     def make_inquiry_string(isc: Section) -> str:
         kwargs = isc._unpack()
@@ -461,6 +468,12 @@ def _cmd_start(config: Section) -> None:  # pylint: disable=too-many-statements,
     if cod.camera.enabled:
         logger.info("===== Camera =====")
         gc.add_camera(["camera"], cod.camera.start, cod.camera.controls.ct_mask, cod.camera.controls.pu_mask)
+
+    # Keep new functions after the established ones so endpoint-constrained
+    # configurations retain their existing allocation priority.
+    if config.kvmd.hid.type == "otg":
+        logger.info("===== HID-Consumer =====")
+        gc.add_consumer(["hid", "consumer"], cod.hid.consumer.start, config.otg.remote_wakeup)
 
     logger.info("===== Preparing complete =====")
 

--- a/kvmd/apps/otg/hid/consumer.py
+++ b/kvmd/apps/otg/hid/consumer.py
@@ -1,0 +1,49 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+from . import Hid
+
+
+# =====
+def make_consumer_hid() -> Hid:
+    return Hid(
+        protocol=0,  # None protocol
+        subclass=0,  # No subclass
+
+        report_length=2,
+
+        report_descriptor=bytes([
+            # https://learn.microsoft.com/en-us/windows-hardware/drivers/hid/display-brightness-control
+
+            0x05, 0x0C,  # USAGE_PAGE (Consumer Devices)
+            0x09, 0x01,  # USAGE (Consumer Control)
+            0xA1, 0x01,  # COLLECTION (Application)
+            0x15, 0x00,  # LOGICAL_MINIMUM (0)
+            0x26, 0xFF, 0x03,  # LOGICAL_MAXIMUM (0x3FF)
+            0x19, 0x00,  # USAGE_MINIMUM (Unassigned)
+            0x2A, 0xFF, 0x03,  # USAGE_MAXIMUM (0x3FF)
+            0x75, 0x10,  # REPORT_SIZE (16)
+            0x95, 0x01,  # REPORT_COUNT (1)
+            0x81, 0x00,  # INPUT (Data,Array,Abs)
+            0xC0,  # END_COLLECTION
+        ]),
+    )

--- a/kvmd/plugins/hid/otg/__init__.py
+++ b/kvmd/plugins/hid/otg/__init__.py
@@ -20,12 +20,14 @@
 # ========================================================================== #
 
 
-import asyncio
 import copy
+import os
+import asyncio
 
 from typing import AsyncGenerator
 
 from .... import aiomulti
+from .... import usb
 
 from ....yamlconf import Section
 from ....yamlconf import Option
@@ -37,8 +39,10 @@ from ....validators.os import valid_abs_path
 
 from .. import BaseHid
 
+from .consumer import ConsumerProcess
 from .keyboard import KeyboardProcess
 from .mouse import MouseProcess
+from .events import is_consumer_key
 
 
 # =====
@@ -59,6 +63,10 @@ class Plugin(BaseHid):  # pylint: disable=too-many-instance-attributes
             }
 
         self.__keyboard_proc = KeyboardProcess(**make_kwargs(c.keyboard))
+        self.__consumer_proc = ConsumerProcess(**make_kwargs(c.consumer))
+        # kvmd-otg keeps this instance stable even when the alternate mouse is disabled.
+        # Unlike the hidg node, this profile link exists only while the function is active.
+        self.__consumer_profile_path = usb.get_gadget_path(usb.G_PROFILE, "hid.usb3")
         self.__mouse_current = self.__mouse_proc = MouseProcess(
             absolute=c.mouse.absolute,
             horizontal_wheel=c.mouse.horizontal_wheel,
@@ -93,6 +101,12 @@ class Plugin(BaseHid):  # pylint: disable=too-many-instance-attributes
                 "queue_timeout":  Option(0.1, type=valid_float_f01),
                 "write_retries":  Option(150, type=valid_int_f1),
             },
+            "consumer": {
+                "device":         Option("/dev/kvmd-hid-consumer", type=valid_abs_path),
+                "select_timeout": Option(0.1, type=valid_float_f01),
+                "queue_timeout":  Option(0.1, type=valid_float_f01),
+                "write_retries":  Option(150, type=valid_int_f1),
+            },
             "mouse": {
                 "device":             Option("/dev/kvmd-hid-mouse", type=valid_abs_path),
                 "select_timeout":     Option(0.1,   type=valid_float_f01),
@@ -117,6 +131,7 @@ class Plugin(BaseHid):  # pylint: disable=too-many-instance-attributes
 
     async def sysprep(self) -> None:
         self.__keyboard_proc.start()
+        self.__consumer_proc.start()
         self.__mouse_proc.start()
         if self.__mouse_alt_proc:
             self.__mouse_alt_proc.start()
@@ -163,6 +178,7 @@ class Plugin(BaseHid):  # pylint: disable=too-many-instance-attributes
 
     async def reset(self) -> None:
         self.__keyboard_proc.send_reset_event()
+        self.__consumer_proc.send_reset_event()
         self.__mouse_proc.send_reset_event()
         if self.__mouse_alt_proc:
             self.__mouse_alt_proc.send_reset_event()
@@ -170,6 +186,7 @@ class Plugin(BaseHid):  # pylint: disable=too-many-instance-attributes
     async def cleanup(self) -> None:
         coros = [
             self.__keyboard_proc.cleanup(),
+            self.__consumer_proc.cleanup(),
             self.__mouse_proc.cleanup(),
         ]
         if self.__mouse_alt_proc:
@@ -197,7 +214,18 @@ class Plugin(BaseHid):  # pylint: disable=too-many-instance-attributes
             self.__notifier.notify()
 
     def _send_key_event(self, key: int, state: bool) -> None:
-        self.__keyboard_proc.send_key_event(key, state)
+        if not is_consumer_key(key):
+            self.__keyboard_proc.send_key_event(key, state)
+        elif state:
+            if os.path.exists(self.__consumer_profile_path):
+                self.__consumer_proc.send_key_event(key, True)
+            else:
+                self.__keyboard_proc.send_key_event(key, True)
+        else:
+            # The Consumer function can be toggled between key-down and key-up.
+            # Releasing both outputs prevents either process from retaining a key.
+            self.__keyboard_proc.send_key_event(key, False)
+            self.__consumer_proc.send_key_event(key, False)
 
     def _send_mouse_button_event(self, button: int, state: bool) -> None:
         self.__mouse_current.send_button_event(button, state)
@@ -213,6 +241,7 @@ class Plugin(BaseHid):  # pylint: disable=too-many-instance-attributes
 
     def _clear_events(self) -> None:
         self.__keyboard_proc.send_clear_event()
+        self.__consumer_proc.send_clear_event()
         self.__mouse_proc.send_clear_event()
         if self.__mouse_alt_proc:
             self.__mouse_alt_proc.send_clear_event()

--- a/kvmd/plugins/hid/otg/consumer.py
+++ b/kvmd/plugins/hid/otg/consumer.py
@@ -1,0 +1,82 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+from typing import Any
+from typing import Generator
+
+from ....logging import get_logger
+
+from .device import BaseDeviceProcess
+
+from .events import BaseEvent
+from .events import ClearEvent
+from .events import ResetEvent
+from .events import ConsumerEvent
+from .events import make_consumer_event
+from .events import make_consumer_report
+
+
+# =====
+class ConsumerProcess(BaseDeviceProcess):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(
+            name="consumer",
+            read_size=0,
+            initial_state={},
+            **kwargs,
+        )
+
+        self.__pressed_usages: list[int] = []
+
+    async def cleanup(self) -> None:
+        try:
+            await self._stop()
+        finally:
+            get_logger().info("Clearing HID-consumer events ...")
+            self._cleanup_write(make_consumer_report(0))
+
+    def send_clear_event(self) -> None:
+        self._clear_queue()
+        self._queue_event(ClearEvent())
+
+    def send_reset_event(self) -> None:
+        self._clear_queue()
+        self._queue_event(ResetEvent())
+
+    def send_key_event(self, key: int, state: bool) -> None:
+        self._queue_event(make_consumer_event(key, state))
+
+    # =====
+
+    def _process_event(self, event: BaseEvent) -> Generator[bytes]:
+        if isinstance(event, (ClearEvent, ResetEvent)):
+            self.__pressed_usages = []
+        elif isinstance(event, ConsumerEvent):
+            if event.state:
+                if event.usage not in self.__pressed_usages:
+                    self.__pressed_usages.append(event.usage)
+            elif event.usage in self.__pressed_usages:
+                self.__pressed_usages.remove(event.usage)
+        else:
+            raise RuntimeError(f"Not implemented event: {event}")
+        usage = (self.__pressed_usages[-1] if self.__pressed_usages else 0)
+        yield make_consumer_report(usage)

--- a/kvmd/plugins/hid/otg/events.py
+++ b/kvmd/plugins/hid/otg/events.py
@@ -23,6 +23,8 @@
 import struct
 import dataclasses
 
+from typing import Final
+
 from evdev import ecodes
 
 from ....keyboard.mappings import UsbKey
@@ -43,6 +45,33 @@ class ClearEvent(BaseEvent):
 
 class ResetEvent(BaseEvent):
     pass
+
+
+# =====
+@dataclasses.dataclass(frozen=True)
+class ConsumerEvent(BaseEvent):
+    usage: int
+    state: bool
+
+
+_CONSUMER_KEYMAP: Final[dict[int, int]] = {
+    ecodes.KEY_MUTE:       0xE2,
+    ecodes.KEY_VOLUMEUP:   0xE9,
+    ecodes.KEY_VOLUMEDOWN: 0xEA,
+}
+
+
+def is_consumer_key(key: int) -> bool:
+    return (key in _CONSUMER_KEYMAP)
+
+
+def make_consumer_event(key: int, state: bool) -> ConsumerEvent:
+    return ConsumerEvent(_CONSUMER_KEYMAP[key], state)
+
+
+def make_consumer_report(usage: int) -> bytes:
+    assert 0 <= usage <= 0x3FF
+    return struct.pack("<H", usage)
 
 
 # =====

--- a/testenv/tests/apps/localhid/__init__.py
+++ b/testenv/tests/apps/localhid/__init__.py
@@ -1,0 +1,20 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #

--- a/testenv/tests/apps/localhid/test_hid.py
+++ b/testenv/tests/apps/localhid/test_hid.py
@@ -1,0 +1,211 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+import asyncio
+
+from collections.abc import AsyncGenerator
+
+import evdev
+from evdev import ecodes
+
+import pytest
+
+from kvmd.apps.localhid.hid import Hid
+
+
+# =====
+class _InputDevice:
+    def __init__(self, caps: dict[int, list[int]], events: list[evdev.InputEvent] | None=None) -> None:
+        self.path = "/dev/input/event-test"
+        self.name = "Test device"
+        self.phys = "test/input0"
+
+        self.__caps = caps
+        self.__events = (events or [])
+
+        self.grabbed = False
+        self.closed = False
+
+    def capabilities(self, *, absinfo: bool) -> dict[int, list[int]]:
+        assert not absinfo
+        return self.__caps
+
+    def grab(self) -> None:  # noqa: vulture-unused
+        self.grabbed = True
+
+    def ungrab(self) -> None:  # noqa: vulture-unused
+        self.grabbed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def async_read_loop(self) -> AsyncGenerator[evdev.InputEvent]:
+        for event in self.__events:
+            yield event
+
+
+def _make_hid(monkeypatch, device: _InputDevice) -> Hid:  # type: ignore
+    monkeypatch.setattr(evdev, "InputDevice", lambda _path: device)
+    return Hid(device.path)
+
+
+def _make_event(event_type: int, code: int, value: int) -> evdev.InputEvent:
+    return evdev.InputEvent(0, 0, event_type, code, value)
+
+
+# =====
+@pytest.mark.parametrize(("keys", "rels", "suitable"), [
+    ([ecodes.KEY_LEFTCTRL], [], True),
+    ([ecodes.KEY_VOLUMEUP, ecodes.KEY_VOLUMEDOWN], [], True),
+    ([ecodes.KEY_POWER, ecodes.KEY_SLEEP, ecodes.KEY_WAKEUP], [], False),
+    ([ecodes.KEY_PLAYPAUSE], [], False),
+    ([ecodes.BTN_LEFT], [ecodes.REL_X], True),
+])
+def test_ok__suitable(monkeypatch, keys: list[int], rels: list[int], suitable: bool) -> None:  # type: ignore
+    hid = _make_hid(monkeypatch, _InputDevice({
+        ecodes.EV_KEY: keys,
+        ecodes.EV_REL: rels,
+    }))
+    assert hid.is_suitable() is suitable
+
+
+@pytest.mark.asyncio
+async def test_ok__consumer_keys(monkeypatch) -> None:  # type: ignore
+    device = _InputDevice(
+        caps={
+            ecodes.EV_SYN: [ecodes.SYN_REPORT],
+            ecodes.EV_KEY: [
+                ecodes.KEY_MUTE,
+                ecodes.KEY_VOLUMEUP,
+                ecodes.KEY_VOLUMEDOWN,
+                ecodes.KEY_PLAYPAUSE,
+                ecodes.KEY_POWER,
+            ],
+        },
+        events=[
+            _make_event(ecodes.EV_KEY, ecodes.KEY_VOLUMEUP, 1),
+            _make_event(ecodes.EV_KEY, ecodes.KEY_VOLUMEUP, 0),
+            _make_event(ecodes.EV_KEY, ecodes.KEY_PLAYPAUSE, 1),
+            _make_event(ecodes.EV_KEY, ecodes.KEY_POWER, 1),
+        ],
+    )
+    hid = _make_hid(monkeypatch, device)
+    queue: asyncio.Queue[tuple[int, tuple]] = asyncio.Queue()
+
+    hid.set_grabbed(True)
+    await hid.poll_to_queue(queue)
+
+    assert device.grabbed
+    assert [queue.get_nowait(), queue.get_nowait()] == [
+        (Hid.KEY, (ecodes.KEY_VOLUMEUP, True)),
+        (Hid.KEY, (ecodes.KEY_VOLUMEUP, False)),
+    ]
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_ok__consumer_keys_while_ungrabbed(monkeypatch) -> None:  # type: ignore
+    device = _InputDevice(
+        caps={
+            ecodes.EV_KEY: [
+                ecodes.KEY_MUTE,
+                ecodes.KEY_VOLUMEUP,
+                ecodes.KEY_VOLUMEDOWN,
+            ],
+        },
+        events=[
+            _make_event(ecodes.EV_REL, ecodes.KEY_VOLUMEUP, 1),
+            _make_event(ecodes.EV_KEY, ecodes.KEY_VOLUMEUP, 2),
+            _make_event(ecodes.EV_KEY, ecodes.KEY_PLAYPAUSE, 1),
+            _make_event(ecodes.EV_KEY, ecodes.KEY_VOLUMEDOWN, 3),
+            _make_event(ecodes.EV_KEY, ecodes.KEY_MUTE, 1),
+        ],
+    )
+    hid = _make_hid(monkeypatch, device)
+    queue: asyncio.Queue[tuple[int, tuple]] = asyncio.Queue()
+
+    await hid.poll_to_queue(queue)
+
+    assert [queue.get_nowait(), queue.get_nowait()] == [
+        (Hid.KEY, (ecodes.KEY_VOLUMEDOWN, True)),
+        (Hid.KEY, (ecodes.KEY_MUTE, True)),
+    ]
+    assert queue.empty()
+
+
+def test_ok__consumer_string(monkeypatch) -> None:  # type: ignore
+    hid = _make_hid(monkeypatch, _InputDevice({
+        ecodes.EV_KEY: [ecodes.KEY_VOLUMEUP],
+    }))
+
+    assert str(hid) == "Hid('/dev/input/event-test', 'Test device', 'test/input0', consumer)"
+
+
+@pytest.mark.asyncio
+async def test_ok__keyboard_keeps_power_key(monkeypatch) -> None:  # type: ignore
+    device = _InputDevice(
+        caps={
+            ecodes.EV_SYN: [ecodes.SYN_REPORT],
+            ecodes.EV_KEY: [ecodes.KEY_LEFTCTRL, ecodes.KEY_POWER],
+        },
+        events=[
+            _make_event(ecodes.EV_KEY, ecodes.KEY_POWER, 1),
+            _make_event(ecodes.EV_KEY, ecodes.KEY_POWER, 0),
+        ],
+    )
+    hid = _make_hid(monkeypatch, device)
+    queue: asyncio.Queue[tuple[int, tuple]] = asyncio.Queue()
+
+    hid.set_grabbed(True)
+    await hid.poll_to_queue(queue)
+
+    assert [queue.get_nowait(), queue.get_nowait()] == [
+        (Hid.KEY, (ecodes.KEY_POWER, True)),
+        (Hid.KEY, (ecodes.KEY_POWER, False)),
+    ]
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_ok__relative_mouse_keeps_key_events(monkeypatch) -> None:  # type: ignore
+    device = _InputDevice(
+        caps={
+            ecodes.EV_SYN: [ecodes.SYN_REPORT],
+            ecodes.EV_KEY: [ecodes.BTN_LEFT, ecodes.KEY_PLAYPAUSE],
+            ecodes.EV_REL: [ecodes.REL_X],
+        },
+        events=[
+            _make_event(ecodes.EV_KEY, ecodes.KEY_PLAYPAUSE, 1),
+            _make_event(ecodes.EV_KEY, ecodes.KEY_PLAYPAUSE, 0),
+        ],
+    )
+    hid = _make_hid(monkeypatch, device)
+    queue: asyncio.Queue[tuple[int, tuple]] = asyncio.Queue()
+
+    hid.set_grabbed(True)
+    await hid.poll_to_queue(queue)
+
+    assert [queue.get_nowait(), queue.get_nowait()] == [
+        (Hid.KEY, (ecodes.KEY_PLAYPAUSE, True)),
+        (Hid.KEY, (ecodes.KEY_PLAYPAUSE, False)),
+    ]
+    assert queue.empty()

--- a/testenv/tests/apps/otg/__init__.py
+++ b/testenv/tests/apps/otg/__init__.py
@@ -1,0 +1,20 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #

--- a/testenv/tests/apps/otg/test_consumer.py
+++ b/testenv/tests/apps/otg/test_consumer.py
@@ -1,0 +1,187 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+import json
+import os
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from typing import Any
+from typing import cast
+
+import pytest
+
+from kvmd.apps import otg
+from kvmd.apps._scheme import make_config_scheme
+
+from kvmd.apps.otg.hid.consumer import make_consumer_hid
+
+from kvmd.yamlconf import Section
+
+
+class _Section(SimpleNamespace):
+    def _unpack(self, ignore: (list[str] | str | None)=None) -> dict[str, Any]:
+        if isinstance(ignore, str):
+            ignore = [ignore]
+        return {
+            key: value
+            for (key, value) in vars(self).items()
+            if key not in (ignore or [])
+        }
+
+
+def _make_config(endpoints: int, mouse_alt_device: str, consumer_start: bool=True) -> _Section:
+    inquiry_string = _Section(vendor=None, product="Drive", revision="1.00")
+    return _Section(
+        kvmd=_Section(
+            hid=_Section(
+                type="otg",
+                mouse=_Section(absolute=True, horizontal_wheel=True),
+                mouse_alt=_Section(device=mouse_alt_device),
+            ),
+            msd=_Section(type="otg"),
+        ),
+        otg=_Section(
+            vendor_id=0x1D6B,
+            product_id=0x0104,
+            usb_version=0x0200,
+            device_version=-1,
+            manufacturer="PiKVM",
+            product="PiKVM Composite Device",
+            serial=None,
+            config=None,
+            max_power=250,
+            remote_wakeup=True,
+            udc="",
+            meta="/run/kvmd/otg",
+            endpoints=endpoints,
+            init_delay=0,
+            user="root",
+            devices=_Section(
+                hid=_Section(
+                    keyboard=_Section(start=True),
+                    mouse=_Section(start=True),
+                    mouse_alt=_Section(start=True),
+                    consumer=_Section(start=consumer_start),
+                ),
+                msd=_Section(
+                    start=True,
+                    default=_Section(
+                        image_path="",
+                        stall=False,
+                        cdrom=True,
+                        rw=False,
+                        removable=True,
+                        fua=True,
+                        inquiry_string=_Section(cdrom=inquiry_string, flash=inquiry_string),
+                    ),
+                ),
+                drives=_Section(enabled=False),
+                ethernet=_Section(enabled=False),
+                serial=_Section(enabled=False),
+                audio=_Section(
+                    enabled=False,
+                    speakers=_Section(enabled=False),
+                    mic=_Section(enabled=False),
+                ),
+                camera=_Section(enabled=False),
+            ),
+        ),
+    )
+
+
+# =====
+def test_ok__consumer_hid() -> None:
+    hid = make_consumer_hid()
+
+    assert hid.protocol == 0
+    assert hid.subclass == 0
+    assert hid.report_length == 2
+    assert hid.report_descriptor == bytes.fromhex(
+        "05 0C 09 01 A1 01 15 00 26 FF 03 19 00 2A FF 03 75 10 95 01 81 00 C0"
+    )
+
+
+def test_ok__consumer_default_off() -> None:
+    scheme = make_config_scheme()
+
+    assert scheme["otg"]["devices"]["hid"]["consumer"]["start"].default is False
+
+
+@pytest.mark.parametrize(("endpoints", "mouse_alt_device", "consumer_start", "started"), [
+    (3, "/dev/kvmd-hid-mouse-alt", True, {"hid.usb0", "hid.usb1", "hid.usb2"}),
+    (5, "/dev/kvmd-hid-mouse-alt", True, {"hid.usb0", "hid.usb1", "hid.usb2", "mass_storage.usb0"}),
+    (5, "", True, {"hid.usb0", "hid.usb1", "mass_storage.usb0", "hid.usb3"}),
+    (5, "", False, {"hid.usb0", "hid.usb1", "mass_storage.usb0"}),
+])
+# pylint: disable=protected-access
+def test_ok__consumer_preserves_existing_allocations(  # type: ignore
+    monkeypatch,
+    endpoints: int,
+    mouse_alt_device: str,
+    consumer_start: bool,
+    started: set[str],
+) -> None:
+    meta: dict[str, dict] = {}
+    links: set[str] = set()
+    writes: dict[str, (str | bytes | int)] = {}
+
+    def record_write(path: str, value: (str | bytes | int), optional: bool=False) -> None:
+        del optional
+        writes[path] = value
+        if path.endswith("@meta.json"):
+            meta[os.path.basename(path).removesuffix("@meta.json")] = json.loads(str(value))
+
+    monkeypatch.setattr(otg, "_mkdir", lambda _path: None)
+    monkeypatch.setattr(otg, "_write", record_write)
+    monkeypatch.setattr(otg, "_write_bytes", lambda _path, _data: None)
+    monkeypatch.setattr(otg, "_chown", lambda _path, _user: None)
+    monkeypatch.setattr(otg, "_symlink", lambda _src, dest: links.add(os.path.basename(dest)))
+    monkeypatch.setattr(otg.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(otg.usb, "get_gadget_path", lambda: "/sys/kernel/config/usb_gadget/kvmd")
+    monkeypatch.setattr(otg.usb, "find_udc", lambda _udc: "fe980000.usb")
+    monkeypatch.setattr(otg.time, "sleep", lambda _delay: None)
+
+    otg._cmd_start(cast(Section, _make_config(endpoints, mouse_alt_device, consumer_start)))
+
+    assert meta["hid.usb2"]["description"] == "Relative Mouse"
+    assert meta["hid.usb3"]["description"] == "Consumer Control"
+    assert meta["hid.usb3"]["starter"] == ["otg", "devices", "hid", "consumer", "start"]
+    assert writes["/sys/kernel/config/usb_gadget/kvmd/bcdDevice"] == "0x0100"
+    assert links == started
+
+
+def test_ok__consumer_udev_mapping() -> None:
+    rules_dir = Path(__file__).resolve().parents[4] / "configs/os/udev"
+    rules = [
+        path
+        for path in rules_dir.glob("*.rules")
+        if "kvmd-hid-mouse-alt" in path.read_text()
+    ]
+
+    assert len(rules) == 7
+    for path in rules:
+        text = path.read_text()
+        assert 'KERNEL=="hidg2", GROUP="kvmd", SYMLINK+="kvmd-hid-mouse-alt"' in text
+        assert 'KERNEL=="hidg3", GROUP="kvmd", SYMLINK+="kvmd-hid-consumer"' in text
+# pylint: enable=protected-access

--- a/testenv/tests/plugins/hid/__init__.py
+++ b/testenv/tests/plugins/hid/__init__.py
@@ -1,0 +1,20 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #

--- a/testenv/tests/plugins/hid/otg/__init__.py
+++ b/testenv/tests/plugins/hid/otg/__init__.py
@@ -1,0 +1,20 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #

--- a/testenv/tests/plugins/hid/otg/test_consumer.py
+++ b/testenv/tests/plugins/hid/otg/test_consumer.py
@@ -1,0 +1,182 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+from evdev import ecodes
+
+import pytest
+
+from kvmd import aiomulti
+
+from kvmd.plugins.hid.otg import Plugin
+from kvmd.plugins.hid.otg.consumer import ConsumerProcess
+from kvmd.plugins.hid.otg.events import BaseEvent
+from kvmd.plugins.hid.otg.events import ClearEvent
+from kvmd.plugins.hid.otg.events import ConsumerEvent
+from kvmd.plugins.hid.otg.events import is_consumer_key
+from kvmd.plugins.hid.otg.events import make_consumer_event
+from kvmd.plugins.hid.otg.events import make_consumer_report
+
+
+_CONSUMER_PROFILE_PATH = "/sys/kernel/config/usb_gadget/kvmd/configs/c.1/hid.usb3"
+
+
+# =====
+@pytest.mark.parametrize(("key", "usage"), [
+    (ecodes.KEY_MUTE, 0xE2),
+    (ecodes.KEY_VOLUMEUP, 0xE9),
+    (ecodes.KEY_VOLUMEDOWN, 0xEA),
+])
+def test_ok__consumer_event(key: int, usage: int) -> None:
+    assert is_consumer_key(key)
+    assert make_consumer_event(key, True) == ConsumerEvent(usage, True)
+    assert make_consumer_report(usage) == usage.to_bytes(2, "little")
+
+
+def test_ok__regular_key() -> None:
+    assert not is_consumer_key(ecodes.KEY_A)
+    with pytest.raises(KeyError):
+        make_consumer_event(ecodes.KEY_A, True)
+
+
+# pylint: disable=protected-access
+def test_ok__consumer_process() -> None:
+    process = ConsumerProcess(
+        notifier=aiomulti.AioMpNotifier(),
+        noop=True,
+        device_path="/dev/null",
+        select_timeout=0.1,
+        queue_timeout=0.1,
+        write_retries=1,
+    )
+
+    assert list(process._process_event(ConsumerEvent(0xE9, True))) == [b"\xE9\x00"]
+    assert list(process._process_event(ConsumerEvent(0xEA, True))) == [b"\xEA\x00"]
+    assert list(process._process_event(ConsumerEvent(0xE9, False))) == [b"\xEA\x00"]
+    assert list(process._process_event(ConsumerEvent(0xEA, False))) == [b"\x00\x00"]
+
+    assert list(process._process_event(ConsumerEvent(0xE9, True))) == [b"\xE9\x00"]
+    assert list(process._process_event(ConsumerEvent(0xEA, True))) == [b"\xEA\x00"]
+    assert list(process._process_event(ConsumerEvent(0xEA, False))) == [b"\xE9\x00"]
+    assert list(process._process_event(ConsumerEvent(0xE9, False))) == [b"\x00\x00"]
+
+    assert list(process._process_event(ClearEvent())) == [b"\x00\x00"]
+
+    with pytest.raises(RuntimeError):
+        list(process._process_event(BaseEvent()))
+
+
+@pytest.mark.parametrize(("consumer_available", "keyboard_events", "consumer_events"), [
+    (True, [(ecodes.KEY_A, True)], [(ecodes.KEY_VOLUMEUP, True)]),
+    (False, [(ecodes.KEY_A, True), (ecodes.KEY_VOLUMEUP, True)], []),
+])
+def test_ok__plugin_key_routing(  # type: ignore
+    monkeypatch,
+    consumer_available: bool,
+    keyboard_events: list[tuple[int, bool]],
+    consumer_events: list[tuple[int, bool]],
+) -> None:
+    class _Recorder:
+        def __init__(self) -> None:
+            self.events: list[tuple[int, bool]] = []
+
+        def send_key_event(self, key: int, state: bool) -> None:
+            self.events.append((key, state))
+
+    keyboard = _Recorder()
+    consumer = _Recorder()
+    plugin = Plugin.__new__(Plugin)
+    setattr(plugin, "_Plugin__keyboard_proc", keyboard)
+    setattr(plugin, "_Plugin__consumer_proc", consumer)
+    setattr(plugin, "_Plugin__consumer_profile_path", _CONSUMER_PROFILE_PATH)
+    checked_paths: list[str] = []
+
+    def exists(path: str) -> bool:
+        checked_paths.append(path)
+        return consumer_available
+
+    monkeypatch.setattr("kvmd.plugins.hid.otg.os.path.exists", exists)
+
+    plugin._send_key_event(ecodes.KEY_A, True)
+    plugin._send_key_event(ecodes.KEY_VOLUMEUP, True)
+
+    assert keyboard.events == keyboard_events
+    assert consumer.events == consumer_events
+    assert checked_paths == [_CONSUMER_PROFILE_PATH]
+
+
+@pytest.mark.parametrize(("press_available", "release_available", "keyboard_events", "consumer_events"), [
+    (
+        True,
+        False,
+        [(ecodes.KEY_VOLUMEUP, False)],
+        [(ecodes.KEY_VOLUMEUP, True), (ecodes.KEY_VOLUMEUP, False)],
+    ),
+    (
+        False,
+        True,
+        [(ecodes.KEY_VOLUMEUP, True), (ecodes.KEY_VOLUMEUP, False)],
+        [(ecodes.KEY_VOLUMEUP, False)],
+    ),
+])
+def test_ok__plugin_key_release_clears_both_outputs(  # type: ignore
+    monkeypatch,
+    press_available: bool,
+    release_available: bool,
+    keyboard_events: list[tuple[int, bool]],
+    consumer_events: list[tuple[int, bool]],
+) -> None:
+    class _Recorder:
+        def __init__(self) -> None:
+            self.events: list[tuple[int, bool]] = []
+
+        def send_key_event(self, key: int, state: bool) -> None:
+            self.events.append((key, state))
+
+    keyboard = _Recorder()
+    consumer = _Recorder()
+    plugin = Plugin.__new__(Plugin)
+    setattr(plugin, "_Plugin__keyboard_proc", keyboard)
+    setattr(plugin, "_Plugin__consumer_proc", consumer)
+    setattr(plugin, "_Plugin__consumer_profile_path", _CONSUMER_PROFILE_PATH)
+    availability = [press_available]
+    checks: list[bool] = []
+
+    def exists(_path: str) -> bool:
+        checks.append(availability[0])
+        return availability[0]
+
+    monkeypatch.setattr("kvmd.plugins.hid.otg.os.path.exists", exists)
+
+    plugin._send_key_event(ecodes.KEY_VOLUMEUP, True)
+    availability[0] = release_available
+    plugin._send_key_event(ecodes.KEY_VOLUMEUP, False)
+
+    assert checks == [press_available]
+    assert keyboard.events == keyboard_events
+    assert consumer.events == consumer_events
+# pylint: enable=protected-access
+
+
+@pytest.mark.parametrize("usage", [-1, 0x400])
+def test_fail__consumer_report(usage: int) -> None:
+    with pytest.raises(AssertionError):
+        make_consumer_report(usage)


### PR DESCRIPTION
## Summary

Forward supported media keys from separate local USB Consumer Control nodes. The dedicated OTG
Consumer Control function is opt-in and defaults to inactive, so existing endpoint allocation and
host-visible USB topology remain unchanged unless an administrator enables it.

Fixes pikvm/pikvm#1690

## Root cause

`kvmd-localhid` only admitted devices that looked like a full keyboard or relative mouse. Receivers
that expose media keys through a separate Consumer Control input node were therefore skipped.

Mute and volume have legacy Keyboard-page mappings, so they can continue through the established
keyboard endpoint by default. That mapping is not portable to every host, however: the tested
Windows host ignored Keyboard-page Volume Up while accepting the corresponding Consumer-page
usage.

## Changes

- Admit Consumer-only input nodes when they expose `KEY_MUTE`, `KEY_VOLUMEUP`, or
  `KEY_VOLUMEDOWN`, while continuing to reject System Control-only nodes and unsupported usages.
- Define a two-byte Consumer Control HID function at the stable `hidg3` allocation, after the
  established keyboard, mouse, and reserved alternate-mouse minors.
- Default `otg.devices.hid.consumer.start` to `false`. The inactive preset consumes no endpoint and
  creates no additional host interface.
- Route supported media keys through the existing keyboard mapping while the Consumer function is
  inactive, and through the Consumer Usage Page only when its configfs profile link is active.
- Release supported keys to both output workers so disabling the function between key-down and
  key-up cannot leave a held usage behind.
- Add udev aliases and focused tests for classification, routing, reports, endpoint allocation,
  dynamic toggling, and unsupported inputs.

This revision does not change `bcdDevice` generation.

## Validation

```sh
make testenv
make tox CMD="tox -c testenv/tox.ini -e flake8,pylint,mypy,vulture"
make tox CMD="tox -c testenv/tox.ini"
python3 -m pytest \
  testenv/tests/apps/localhid \
  testenv/tests/apps/otg \
  testenv/tests/plugins/hid/otg
```

The native x86_64 tox matrix passed all configured environments: `flake8`, `pylint`, `mypy`,
`vulture`, `pytest`, `eslint`, `htmlhint`, and `shellcheck`. The full pytest environment reported
771 passed; the focused suite reported 28 passed.

The focused suite also passed under the strict Python runtime layer in KVMD's Linux test image.
A diff-scoped mutmut run generated 3,330 file-level mutants: 402 killed, 2,220 survived, 708 not
covered, and no timeouts. This is recorded as broad file-level test-debt evidence, not as an
all-mutants-killed claim.

## Real-device proof

Tested on a PiKVM V4, a USB wireless keyboard/mouse receiver, and a Windows USB host against exact
base `423c2f5a` and exact HEAD `05432129` without rebooting either machine.

- Exact base used two endpoints and exposed only the keyboard (`MI_00`) and relative mouse
  (`MI_01`). Its Keyboard-page volume event left the Windows endpoint unchanged at step 21/51.
- HEAD with the default configuration retained the same two endpoints and `MI_00`/`MI_01`
  topology. The Consumer preset was unlinked, and Windows again ignored the Keyboard-page Volume
  Up mapping.
- Explicitly enabling `hid.usb3` added exactly one endpoint. Windows enumerated an `OK` `MI_02`
  Consumer Control interface; Volume Up moved step 21/51 to 22/51, and a localhid Volume Down event
  restored it to 21/51.
- `kvmd-otgconf -e hid.usb3` worked while KVMD remained running. Disabling the function during a
  held key produced two stable post-disconnect volume readings, with no stuck host key.
- The original gadget, read-only root state, service state, host enumeration, and volume were
  restored after proof.

The current exact-HEAD behavior exercise used the documented KVMD API and a controlled evdev
source; the physical receiver's separate Consumer node was present and opened. Earlier
same-hardware captures additionally recorded physical Volume Up/Down packets through the same
Consumer implementation.

Screenshots are not applicable to this evdev/HID forwarding change.

## Out of scope

This is normalized evdev forwarding, not raw descriptor passthrough. System Control Power/Sleep/
Wake nodes and unsupported Consumer usages remain ignored. The initial supported set is Mute,
Volume Up, and Volume Down.

## Review history

https://gist.github.com/8193ca364a1b25d55eac71121995001b

Authored with AI assistance.
