### PR TITLE
scripts/kvmd-bootconfig: fix race between mkfs and mount

### DIFF
--- a/scripts/kvmd-bootconfig
+++ b/scripts/kvmd-bootconfig
@@ -136,6 +136,8 @@ if [ -n "$FIRSTBOOT$FIRST_BOOT" ]; then
 		umount "$part"
 		parted "$disk" -a optimal -s resizepart "$npart" 100%
 		yes | mkfs.ext4 -L "$label" -F -m 0 "$part"
+		# ensure udev database is up-to-date after mkfs, otherwise mount won't find the fstab entry
+		udevadm trigger --settle --action=change "$part"
 		mount "$part"
 		unset disk part npart label
 	fi


### PR DESCRIPTION
mount(8) reads device properties (e.g., label) from the udev database, which is populated asynchronously. Ensure that the udev database is up-to-date after mkfs, otherwise mount(8) won't find the fstab entry (which is keyed by LABEL=), failing the mount.