### PR TITLE
configs: add a preconfiguration script for `kvmd-camera@.service`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -173,7 +173,7 @@ package_kvmd() {
 	python -m installer --destdir="$pkgdir" dist/*.whl
 
 	install -Dm755 -t "$pkgdir/usr/bin" scripts/kvmd-{bootconfig,gencert,certbot,update-switch}
-	install -Dm755 -t "$pkgdir/usr/lib/kvmd" scripts/kvmd-udev-flash-pico
+	install -Dm755 -t "$pkgdir/usr/lib/kvmd" scripts/kvmd-{udev-flash-pico,ucamera-prepare}
 
 	install -dm755 "$pkgdir/usr/lib/systemd/system"
 	cp -rd configs/os/services -T "$pkgdir/usr/lib/systemd/system"

--- a/configs/os/services/kvmd-camera@.service
+++ b/configs/os/services/kvmd-camera@.service
@@ -6,4 +6,5 @@ After=%i.device
 Type=simple
 Restart=always
 RestartSec=3
+ExecStartPre=-/usr/lib/kvmd/kvmd-ucamera-prepare --device=%f
 ExecStart=/usr/bin/ucamera --device=%f

--- a/configs/os/services/kvmd-camera@.service
+++ b/configs/os/services/kvmd-camera@.service
@@ -1,9 +1,9 @@
 [Unit]
-BindTo=%i.device
+BindsTo=%i.device
 After=%i.device
 
 [Service]
 Type=simple
 Restart=always
 RestartSec=3
-ExecStart=/usr/bin/ucamera --device=/%I
+ExecStart=/usr/bin/ucamera --device=%f


### PR DESCRIPTION
Adjust `kvmd-camera@.service` to invoke a low-level platform configuration script before starting the userspace camera driver. For now, the configuration made is not reversible.