### PR TITLE
web: send boolean mic flag in WATCH request

### DIFF
--- a/web/share/js/kvm/stream_janus.js
+++ b/web/share/js/kvm/stream_janus.js
@@ -659,7 +659,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 			__handle.send({"message": {"request": "watch", "params": {
 				"orientation": __orient,
 				"audio": audio,
-				"mic": mic,
+				"mic": !!mic,
 				"camera": !!__camera_req,
 			}}});
 			__watchHook();


### PR DESCRIPTION
## Problem

Since b2ee3e64 (pikvm/pikvm#1495, v4.198), the microphone is broken: `__sendWatch()` now sends the `mic` param as a device-id string (`".__default__"` or a browser `deviceId`) instead of a boolean.

The Janus uStreamer plugin only accepts booleans here — `READ_BOOL` in `janus/src/plugin.c` (also current on ustreamer master):

```c
if (m_obj != NULL && json_is_boolean(m_obj)) {
    x_target = (json_boolean_value(m_obj) && (x_cond));
}
```

A string fails `json_is_boolean()`, so `with_aplay` stays `false` and the server never starts the mic (aplay) pipeline. Mic is silently dead regardless of UI toggling.

## Fix

Send `!!mic`, matching the existing `"camera": !!__camera_req` pattern. Device selection is unaffected — it is applied client-side via the `getUserMedia` `deviceId` constraint in the SDP capture path, and the WATCH log line still prints the selected device id.

Verified against v4.198 on a V4 Mini (kvmd 4.198-1, ustreamer 6.62-1, janus-gateway-pikvm 1.4.2-2): reverting the mic-related web changes restores the mic, and the plugin-side `json_is_boolean` check is the only place the new payload diverges from what the server accepts.