### PR TITLE
kvmd-bootconfig: support WPA3

### DIFF
--- a/scripts/kvmd-bootconfig
+++ b/scripts/kvmd-bootconfig
@@ -248,10 +248,10 @@ fi
 
 # Set the regulatory domain for wifi, if defined.
 if [ -n "$WIFI_REGDOM" ]; then
-	sed -i \
-			-e 's/^\(WIRELESS_REGDOM=.*\)$/#\1/' \
-			-e 's/^#\(WIRELESS_REGDOM="'"$WIFI_REGDOM"'"\)/\1/' \
-		/etc/conf.d/wireless-regdom
+	sed -r \
+		-e 's/^(WIRELESS_REGDOM=.*)$/#\1/' \
+		-e 's/^#(WIRELESS_REGDOM="'"$WIFI_REGDOM"'")/\1/' \
+		-i /etc/conf.d/wireless-regdom
 fi
 
 # If the WIFI_ESSID is defined, configure wlan0
@@ -275,10 +275,14 @@ end_of_file
 	fi
 	chmod 640 "$_wpa"
 	if [ -n "$WIFI_HIDDEN" ]; then
-		sed -i -e 's/^}/\tscan_ssid=1\n}/g' "$_wpa"
+		sed -r \
+			-e '/^}/i\\tscan_ssid=1' \
+			-i "$_wpa"
 	fi
 	if [ -n "$WIFI_WPA23" ]; then
-		sed -i -e 's/^}/\tkey_mgmt=WPA-PSK-SHA256 WPA-PSK\n\tieee80211w=1\n}/g' "$_wpa"
+		sed -r \
+			-e '/^}/i\\tkey_mgmt=WPA-PSK-SHA256 WPA-PSK\n\tieee80211w=1' \
+			-i "$_wpa"
 	fi
 	systemctl enable "wpa_supplicant@$WIFI_IFACE.service" || true
 	need_reboot

--- a/scripts/kvmd-bootconfig
+++ b/scripts/kvmd-bootconfig
@@ -257,6 +257,7 @@ fi
 # If the WIFI_ESSID is defined, configure wlan0
 if [ -n "$WIFI_ESSID" ]; then
 	WIFI_IFACE="${WIFI_IFACE:-wlan0}"
+	_WIFI_PASSWD_SET=
 	if [ -n "$WIFI_ADDR" ]; then
 		make_static_iface "$WIFI_IFACE" "$WIFI_ADDR" "$WIFI_GW" "$WIFI_DNS" 50
 	else
@@ -264,6 +265,7 @@ if [ -n "$WIFI_ESSID" ]; then
 	fi
 	_wpa="/etc/wpa_supplicant/wpa_supplicant-$WIFI_IFACE.conf"
 	if [ "${#WIFI_PASSWD}" -ge 8 ];then
+		_WIFI_PASSWD_SET=1
 		wpa_passphrase "$WIFI_ESSID" "$WIFI_PASSWD" > "$_wpa"
 	else
 		cat <<end_of_file > "$_wpa"
@@ -279,7 +281,7 @@ end_of_file
 			-e '/^}/i\\tscan_ssid=1' \
 			-i "$_wpa"
 	fi
-	if [ -n "$WIFI_WPA23" ]; then
+	if [ -n "$_WIFI_PASSWD_SET" ] && [ -n "$WIFI_WPA23" ]; then
 		sed -r \
 			-e '/^}/i\\tkey_mgmt=WPA-PSK-SHA256 WPA-PSK\n\tieee80211w=1' \
 			-i "$_wpa"

--- a/scripts/kvmd-bootconfig
+++ b/scripts/kvmd-bootconfig
@@ -281,7 +281,24 @@ end_of_file
 			-e '/^}/i\\tscan_ssid=1' \
 			-i "$_wpa"
 	fi
-	if [ -n "$_WIFI_PASSWD_SET" ] && [ -n "$WIFI_WPA23" ]; then
+	if [ -n "$_WIFI_PASSWD_SET" ] && [ -n "$WIFI_WPA3" ]; then
+		# Patch wpa_supplicant config to enable WPA3 (SAE)
+		# 1. wpa_passphrase generates an uncommented hashed psk= line and a
+		#    commented clear-text psk="..." line; for WPA3 clear-text psk= must be used
+		# 2. add key_mgmt=SAE, ieee80211w=2 network options before the end of the network={ block
+		# 3. add sae_pwe=2 global option before the network={ block
+		sed -r \
+			-e '1i\sae_pwe=2\n' \
+			-e 's/\tpsk=/\t#psk=/g' \
+			-e 's/\t#psk="/\tpsk="/g' \
+			-e '/^}/i\\tkey_mgmt=SAE\n\tieee80211w=2' \
+			-i "$_wpa"
+	elif [ -n "$_WIFI_PASSWD_SET" ] && [ -n "$WIFI_WPA23" ]; then
+		# Patch wpa_supplicant config for interoperability with WPA2/3 mixed mode networks,
+		# which means enabling support for WPA2 PMF (protected management frames)
+		# and a -SHA256 AKM that is commonly used together.
+		# Both changes are additive/optional, to not disallow connecting to a
+		# pure WPA2 (non-PMF) network.
 		sed -r \
 			-e '/^}/i\\tkey_mgmt=WPA-PSK-SHA256 WPA-PSK\n\tieee80211w=1' \
 			-i "$_wpa"


### PR DESCRIPTION
Add support for `WIFI_WPA3=` option in `/boot/pikvm.txt`, which configures
wpa\_supplicant to connect to a WPA3 network. For this to work, patch the
autogenerated `wpa_supplicant-$IFACE.conf` to:
- use clear-text `psk="..."` option instead of the hashed PSK;
- set `key_mgmt=SAE` to negotiate a SAE (WPA3) AKM, and
- set `ieee80211w=2` to require protected management frames as mandated by WPA3.

Additionally, clarify the meaning of `WIFI_WPA23=` in comments and harden both
options to only take effect if a password (`WIFI_PASSWD=`) is set and valid.
