### PR TITLE
Two-way audio in the direct H.264 mode

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -97,6 +97,9 @@ depends=(
 	dnsmasq
 	ipmitool
 	"janus-gateway-pikvm>=1.3.0"
+	alsa-lib
+	opus
+	speexdsp
 	certbot
 	"raspberrypi-io-access>=0.9"
 	raspberrypi-utils

--- a/configs/os/sysusers.conf
+++ b/configs/os/sysusers.conf
@@ -34,6 +34,7 @@ m kvmd kvmd-pst
 m kvmd kvmd-nbd
 
 m kvmd-media kvmd
+m kvmd-media audio
 
 m kvmd-pst kvmd
 

--- a/kvmd/apps/_scheme.py
+++ b/kvmd/apps/_scheme.py
@@ -484,6 +484,16 @@ def make_config_scheme() -> dict:
                     "drop_same_frames": Option(0.0, type=valid_float_f0),
                 },
             },
+
+            "audio": {
+                "device":   Option("plughw:tc358743,0", type=valid_stripped_string, if_empty=""),
+                "tc358743": Option("/dev/kvmd-video",   type=valid_abs_path, if_empty=""),
+            },
+
+            "mic": {
+                "device":  Option("plughw:UAC2Gadget,0", type=valid_stripped_string, if_empty=""),
+                "latency": Option(0.1, type=valid_float_f01),
+            },
         },
 
         "pst": {

--- a/kvmd/apps/media/audio.py
+++ b/kvmd/apps/media/audio.py
@@ -1,0 +1,308 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2020  Maxim Devaev <mdevaev@gmail.com>                    #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+import os
+import fcntl
+import struct
+import asyncio
+import contextlib
+import dataclasses
+
+from typing import Callable
+from typing import Awaitable
+
+from ...logging import get_logger
+
+from ... import tools
+from ... import aiotools
+
+from ...audio import AudioError
+from ...audio import PcmCapture
+from ...audio import OpusEncoder
+from ...audio import Resampler
+
+
+# =====
+class AudioSourceError(Exception):
+    pass
+
+
+# =====
+_VIDIOC_G_CTRL = 0xC008561B  # _IOWR("V", 27, struct v4l2_control)
+_TC358743_CID_AUDIO_SAMPLING_RATE = 0x00981980
+_TC358743_CID_AUDIO_PRESENT = 0x00981981
+
+
+def _get_v4l2_ctrl(fd: int, cid: int) -> int:
+    buf = struct.pack("Ii", cid, 0)
+    return struct.unpack("Ii", fcntl.ioctl(fd, _VIDIOC_G_CTRL, buf))[1]
+
+
+@dataclasses.dataclass
+class _Sub:
+    fmt:      str
+    on_frame: Callable[[bytes], Awaitable[None]]
+    on_error: Callable[[str], Awaitable[None]]
+    queue:    asyncio.Queue[bytes]
+    task:     (asyncio.Task | None) = None
+    gap:      bool = False  # Something was dropped before the next frame
+
+
+# =====
+class AudioSource:
+    # Captures the host audio from the HDMI capture device and sends it to the clients.
+    # The device is captured once and the audio is shared between all of them.
+
+    HZ = 48000
+    CHANNELS = 2
+    FRAME_MS = 20
+    BITRATE = 128000  # The same as uStreamer uses for the WebRTC audio
+
+    FORMAT_OPUS = "opus"
+    FORMAT_PCM = "pcm"
+    FORMATS = [FORMAT_OPUS, FORMAT_PCM]
+
+    __QUEUE_SIZE = 25  # 0.5 seconds of the audio
+    __QUEUE_TRIM = 5   # ... and 0.1 seconds to keep when the client can't eat it
+    __MAX_BROKEN = 10  # Broken frames (a good one heals a single failure) before restarting
+    __BROKEN_LOG = 25  # ... and how often to complain about them
+    __ERROR_DELAY = 1.0
+    __REPORT_AFTER = 5  # Failed attempts before bothering the client with an error
+    __ERROR_LOG = 30    # ... and how often to repeat it in the log
+
+    def __init__(self, device: str, tc358743: str) -> None:
+        self.__device = device
+        self.__tc358743 = tc358743
+
+        self.__subs: dict[object, _Sub] = {}
+        self.__task: (asyncio.Task | None) = None
+        self.__drops = 0
+        self.__no_opus = False
+
+    # =====
+
+    async def get_info(self) -> (dict | None):
+        if not self.__device:
+            return None
+        if not (await asyncio.to_thread(PcmCapture.probe, self.__device)):
+            return None
+        formats = list(self.FORMATS)
+        if not (await asyncio.to_thread(OpusEncoder.probe)):
+            # Without libopus the client should not even try to ask for Opus
+            if not self.__no_opus:
+                self.__no_opus = True
+                get_logger(0).error("No libopus, the audio will use the raw PCM")
+            formats.remove(self.FORMAT_OPUS)
+        return {
+            "formats":  formats,
+            "hz":       self.HZ,
+            "channels": self.CHANNELS,
+            "frame_ms": self.FRAME_MS,
+        }
+
+    async def start(
+        self,
+        owner: object,
+        fmt: str,
+        on_frame: Callable[[bytes], Awaitable[None]],
+        on_error: Callable[[str], Awaitable[None]],
+    ) -> None:
+
+        if not self.__device:
+            raise AudioSourceError("The audio is not configured")
+        if fmt not in self.FORMATS:
+            raise AudioSourceError(f"Unsupported audio format: {fmt}")
+        if fmt == self.FORMAT_OPUS and not (await asyncio.to_thread(OpusEncoder.probe)):
+            raise AudioSourceError("There is no Opus support on the server")
+
+        self.stop(owner)  # Restart if the client has changed the format
+        sub = _Sub(fmt, on_frame, on_error, asyncio.Queue(self.__QUEUE_SIZE))
+        sub.task = asyncio.create_task(self.__sending(sub))
+        self.__subs[owner] = sub
+        if self.__task is None or self.__task.done():
+            self.__task = asyncio.create_task(self.__capturing())
+
+    def stop(self, owner: object) -> None:
+        sub = self.__subs.pop(owner, None)
+        if sub is not None and sub.task is not None:
+            sub.task.cancel()
+
+    # =====
+
+    def __feed(self, sub: _Sub, data: bytes) -> None:
+        try:
+            sub.queue.put_nowait(data)
+        except asyncio.QueueFull:
+            # The client can't eat the audio fast enough. Dropping the oldest frames restores
+            # the latency, but the recent ones are kept: they are the sound the user will hear.
+            with contextlib.suppress(asyncio.QueueEmpty):
+                while sub.queue.qsize() > self.__QUEUE_TRIM:
+                    sub.queue.get_nowait()
+                    self.__drops += 1
+                    sub.gap = True
+            with contextlib.suppress(asyncio.QueueFull):
+                sub.queue.put_nowait(data)
+
+    async def __sending(self, sub: _Sub) -> None:
+        while True:
+            data = (await sub.queue.get())
+            # The first byte marks the discontinuity, the client can't detect it itself
+            flags = (1 if sub.gap else 0)
+            sub.gap = False
+            with contextlib.suppress(Exception):
+                # The dead client will be removed by the server
+                await sub.on_frame(flags.to_bytes() + data)
+
+    async def __report(self, error: str) -> None:
+        for sub in list(self.__subs.values()):
+            with contextlib.suppress(Exception):
+                await sub.on_error(error)
+
+    def __get_host_hz(self) -> int:
+        # The HDMI audio rate is defined by the host, zero means no audio at all
+        if not self.__tc358743:
+            return self.HZ
+        fd = os.open(self.__tc358743, os.O_RDWR)
+        try:
+            if not _get_v4l2_ctrl(fd, _TC358743_CID_AUDIO_PRESENT):
+                return 0
+            return max(_get_v4l2_ctrl(fd, _TC358743_CID_AUDIO_SAMPLING_RATE), 0)
+        finally:
+            os.close(fd)
+
+    async def __capturing(self) -> None:
+        logger = get_logger(0)
+        reported = ""
+        quiet = False
+        fails = 0
+        try:
+            while self.__subs:
+                try:
+                    hz = (await asyncio.to_thread(self.__get_host_hz))
+                    if hz <= 0:
+                        if not quiet:
+                            quiet = True
+                            logger.info("The host doesn't send any audio")
+                        await asyncio.sleep(self.__ERROR_DELAY)
+                        continue
+                    quiet = False
+                    await self.__capture(hz)
+                    (reported, fails) = ("", 0)
+                except (AudioError, OSError) as ex:
+                    error = tools.efmt(ex)
+                    fails += 1
+                    if fails % self.__ERROR_LOG == 1:
+                        logger.error("Audio capture error: %s", error)
+                    if fails >= self.__REPORT_AFTER and reported != error:
+                        # The device stays busy for a few seconds when the user switches
+                        # the video mode, so the transient errors are not worth an alert
+                        reported = error
+                        await self.__report(error)
+                    await asyncio.sleep(self.__ERROR_DELAY)
+                except Exception:
+                    logger.exception("Unexpected audio capture error")
+                    await asyncio.sleep(self.__ERROR_DELAY)
+        finally:
+            logger.info("Audio capture finished")
+
+    def __make_codecs(self, real: int) -> "tuple[Resampler | None, OpusEncoder | None]":
+        res: (Resampler | None) = None
+        if real != self.HZ:
+            # Opus can't eat an arbitrary rate, but the host can send 44.1 kHz for example
+            res = Resampler(self.CHANNELS, real, self.HZ, (real * self.FRAME_MS) // 1000)
+        try:
+            enc = (OpusEncoder(self.HZ, self.CHANNELS, self.BITRATE) if OpusEncoder.probe() else None)
+        except Exception:
+            if res is not None:
+                res.close()
+            raise
+        return (res, enc)
+
+    def __distribute(self, data: bytes, enc: (OpusEncoder | None)) -> None:
+        encoded: (bytes | None) = None
+        for sub in list(self.__subs.values()):
+            if sub.fmt != self.FORMAT_OPUS:
+                self.__feed(sub, data)
+            elif enc is not None:
+                if encoded is None:
+                    encoded = enc.encode(data)
+                self.__feed(sub, encoded)
+
+    async def __capture(self, hz: int) -> None:
+        logger = get_logger(0)
+        cap = PcmCapture(self.__device, hz, self.CHANNELS, self.FRAME_MS)
+        real = (await asyncio.to_thread(cap.open))
+        res: (Resampler | None) = None
+        enc: (OpusEncoder | None) = None
+        try:
+            # Both of them load their libraries on the first use, and that runs ldconfig
+            (res, enc) = (await asyncio.to_thread(self.__make_codecs, real))
+            logger.info("Audio capture started on %s: %d Hz%s; ALSA period=%d buffer=%d",
+                        self.__device, real, ("" if res is None else f" -> {self.HZ} Hz"),
+                        cap.period, cap.buffer)
+            await self.__capturing_loop(cap, res, enc, hz)
+        finally:
+            try:
+                await aiotools.shield_fg(asyncio.to_thread(cap.close))
+            except Exception:
+                logger.exception("Can't close the audio capture")
+            finally:
+                if res is not None:
+                    res.close()
+                if enc is not None:
+                    enc.close()
+            logger.info("Audio capture stopped; overruns: %d, skipped: %d,"
+                        " stalled: %d, dropped: %d",
+                        cap.overruns, cap.skipped, cap.stalled, self.__drops)
+            self.__drops = 0
+
+    async def __capturing_loop(
+        self,
+        cap: PcmCapture,
+        res: (Resampler | None),
+        enc: (OpusEncoder | None),
+        hz: int,
+    ) -> None:
+
+        logger = get_logger(0)
+        (count, broken) = (0, 0)
+        while self.__subs:
+            data = (await aiotools.shield_fg(asyncio.to_thread(cap.read)))
+            if data:
+                try:
+                    self.__distribute((data if res is None else res.process(data)), enc)
+                except AudioError as ex:
+                    # A single broken frame is not a reason to reopen the device,
+                    # but a permanently failing encoder is
+                    broken += 1
+                    if broken % self.__BROKEN_LOG == 1:
+                        logger.error("Can't process the audio frame: %s", tools.efmt(ex))
+                    if broken >= self.__MAX_BROKEN:
+                        raise
+                    continue
+                broken = max(broken - 1, 0)
+            count += 1
+            if count * self.FRAME_MS >= 1000:  # Check the host rate every second
+                count = 0
+                if (await asyncio.to_thread(self.__get_host_hz)) != hz:
+                    logger.info("The host has changed the audio rate")
+                    break

--- a/kvmd/apps/media/mic.py
+++ b/kvmd/apps/media/mic.py
@@ -1,0 +1,215 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2020  Maxim Devaev <mdevaev@gmail.com>                    #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+import asyncio
+import contextlib
+
+from typing import Callable
+from typing import Awaitable
+
+from ...logging import get_logger
+
+from ... import tools
+from ... import aiotools
+
+from ...audio import AudioError
+from ...audio import PcmPlayback
+from ...audio import OpusDecoder
+
+
+# =====
+class MicError(Exception):
+    pass
+
+
+class MicBusyError(MicError):
+    def __init__(self) -> None:
+        super().__init__("The microphone is busy by another client")
+
+
+# =====
+class MicSink:  # pylint: disable=too-many-instance-attributes
+    # Plays the client's microphone to the USB audio gadget.
+    # Only one client can use the playback device at the same time.
+
+    HZ = 48000
+    CHANNELS = 1
+    FRAME_MS = 20
+
+    FORMAT_OPUS = "opus"
+    FORMAT_PCM = "pcm"
+    FORMATS = [FORMAT_OPUS, FORMAT_PCM]
+
+    __QUEUE_SIZE = 25  # 0.5 seconds of the audio
+    __QUEUE_TRIM = 5   # ... and 0.1 seconds to keep when the client sends it too fast
+    __MAX_FRAME = 12288  # 120ms of the raw mono audio, the longest Opus frame is shorter
+    # The websocket handlers are called one by one, so a long wait here would block
+    # the client's pings and the browser would drop the connection
+    __STOP_TIMEOUT = 0.5
+
+    def __init__(self, device: str, latency: float) -> None:
+        self.__device = device
+        self.__latency = latency
+
+        self.__owner: (object | None) = None
+        self.__fmt = ""
+        self.__no_opus = False
+        self.__drops = 0
+        self.__queue: asyncio.Queue[bytes] = asyncio.Queue(self.__QUEUE_SIZE)
+        self.__task: (asyncio.Task | None) = None
+        self.__lock = asyncio.Lock()
+
+    # =====
+
+    async def get_info(self) -> (dict | None):
+        if not self.__device:
+            return None
+        if not (await asyncio.to_thread(PcmPlayback.probe, self.__device)):
+            return None
+        formats = list(self.FORMATS)
+        if not (await asyncio.to_thread(OpusDecoder.probe)):
+            # Without libopus the client should not even try to send Opus
+            if not self.__no_opus:
+                self.__no_opus = True
+                get_logger(0).error("No libopus, the microphone will use the raw PCM")
+            formats.remove(self.FORMAT_OPUS)
+        return {
+            "formats":  formats,
+            "hz":       self.HZ,
+            "channels": self.CHANNELS,
+            "frame_ms": self.FRAME_MS,
+        }
+
+    async def start(self, owner: object, fmt: str, on_error: Callable[[str], Awaitable[None]]) -> None:
+        if not self.__device:
+            raise MicError("The microphone is not configured")
+        if fmt not in self.FORMATS:
+            raise MicError(f"Unsupported microphone format: {fmt}")
+        async with self.__lock:
+            if self.__owner is owner:
+                if fmt != self.__fmt:
+                    raise MicError("The microphone is already started with another format")
+                return
+            if self.__owner is not None:
+                raise MicBusyError()
+            if self.__task is not None:
+                # The previous session is stopping right now, it should be fast
+                (done, _) = await asyncio.wait([self.__task], timeout=self.__STOP_TIMEOUT)
+                if not done:
+                    raise MicBusyError()
+                self.__task = None
+
+            pcm = PcmPlayback(self.__device, self.HZ, self.CHANNELS, self.__latency)
+            dec = (OpusDecoder(self.HZ, self.CHANNELS) if fmt == self.FORMAT_OPUS else None)
+            try:
+                # Shielded: a cancelled open() would leave the device to nobody.
+                # The cancellation arrives after the thread is done, so BaseException.
+                await aiotools.shield_fg(asyncio.to_thread(pcm.open))
+            except BaseException:
+                pcm.close()
+                if dec is not None:
+                    dec.close()
+                raise
+
+            self.__owner = owner
+            self.__fmt = fmt
+            self.__drain()
+            self.__task = asyncio.create_task(self.__playing(pcm, dec, on_error))
+
+    def stop(self, owner: object) -> None:
+        if self.__owner is not None and self.__owner is owner:
+            self.__owner = None
+            self.__drain()
+            self.__queue.put_nowait(b"")  # Stop signal for the playing task
+
+    def feed(self, owner: object, data: bytes) -> None:
+        # A huge frame would occupy the playback device for its whole duration,
+        # and the device is shared between all the clients
+        if self.__owner is not owner or not (0 < len(data) <= self.__MAX_FRAME):
+            return
+        try:
+            self.__queue.put_nowait(data)
+        except asyncio.QueueFull:
+            # The client sends the audio faster than we can play it. Dropping the oldest frames
+            # restores the latency, but the recent ones are kept: they are the actual speech.
+            with contextlib.suppress(asyncio.QueueEmpty):
+                while self.__queue.qsize() > self.__QUEUE_TRIM:
+                    self.__queue.get_nowait()
+                    self.__drops += 1
+            with contextlib.suppress(asyncio.QueueFull):
+                self.__queue.put_nowait(data)
+
+    # =====
+
+    def __drain(self) -> None:
+        with contextlib.suppress(asyncio.QueueEmpty):
+            while True:
+                self.__queue.get_nowait()
+
+    async def __playing(
+        self,
+        pcm: PcmPlayback,
+        dec: (OpusDecoder | None),
+        on_error: Callable[[str], Awaitable[None]],
+    ) -> None:
+
+        logger = get_logger(0)
+        logger.info("Microphone playback started on %s", self.__device)
+        error = ""
+        broken = 0
+        try:
+            while True:
+                data = await self.__queue.get()
+                if len(data) == 0:  # Stop signal
+                    break
+                if dec is not None:
+                    try:
+                        data = dec.decode(data)
+                    except AudioError as ex:
+                        # The broken frame is not a reason to stop the playback
+                        broken += 1
+                        if broken == 1:
+                            logger.error("Can't decode the microphone frame: %s", tools.efmt(ex))
+                        continue
+                await aiotools.shield_fg(asyncio.to_thread(pcm.write, data))
+        except AudioError as ex:
+            error = tools.efmt(ex)
+            logger.error("Microphone playback error: %s", error)
+        except Exception as ex:
+            error = tools.efmt(ex)
+            logger.exception("Unexpected microphone playback error")
+        finally:
+            self.__owner = None
+            try:
+                await aiotools.shield_fg(asyncio.to_thread(pcm.close))
+            except Exception:
+                logger.exception("Can't close the microphone playback")
+            finally:
+                if dec is not None:
+                    dec.close()
+            logger.info("Microphone playback stopped; broken: %d, dropped: %d,"
+                        " underruns: %d, stalled: %d",
+                        broken, self.__drops, pcm.underruns, pcm.stalled)
+            self.__drops = 0
+        if error:
+            with contextlib.suppress(Exception):
+                await on_error(error)

--- a/kvmd/apps/media/server.py
+++ b/kvmd/apps/media/server.py
@@ -21,6 +21,7 @@
 
 
 import asyncio
+import contextlib
 import dataclasses
 
 from aiohttp.web import Request
@@ -43,8 +44,16 @@ from ...clients.streamer import StreamerPermError
 from ...clients.streamer import StreamerFormats
 from ...clients.streamer import BaseStreamerClient
 
+from ...audio import AudioError
+
 from ...validators import ValidatorError
 from ...validators.basic import valid_stripped_string
+
+from .audio import AudioSourceError
+from .audio import AudioSource
+
+from .mic import MicError
+from .mic import MicSink
 
 
 # =====
@@ -88,8 +97,12 @@ class _Client:
 
 class MediaServer(HttpServer):
     __EV_MEDIA = "media"
+    __EV_AUDIO_STATE = "audio_state"
+    __EV_MIC_STATE = "mic_state"
 
     __T_VIDEO = "video"
+    __T_AUDIO = "audio"
+    __T_MIC = "mic"
 
     __F_H264 = "h264"
     __F_JPEG = "jpeg"
@@ -98,9 +111,14 @@ class MediaServer(HttpServer):
         self,
         h264_streamer: (BaseStreamerClient | None),
         jpeg_streamer: (BaseStreamerClient | None),
+        audio: AudioSource,
+        mic: MicSink,
     ) -> None:
 
         super().__init__()
+
+        self.__audio = audio
+        self.__mic = mic
 
         self.__media: dict[str, dict[str, _Source]] = {self.__T_VIDEO: {}}
         if h264_streamer:
@@ -113,7 +131,7 @@ class MediaServer(HttpServer):
     @exposed_http("GET", "/")
     async def __root_handler(self, _: Request) -> Response:
         return make_json_response({
-            self.__EV_MEDIA: self.__get_media_info(),
+            self.__EV_MEDIA: (await self.__get_media_info()),
         })
 
     # ===== WEBSOCKET
@@ -129,7 +147,7 @@ class MediaServer(HttpServer):
                 if not self.__start_stream(ws, self.__T_VIDEO, v_fmt):
                     raise RuntimeError("We shouldn't be here")
             else:
-                await ws.send_event(self.__EV_MEDIA, self.__get_media_info())
+                await ws.send_event(self.__EV_MEDIA, (await self.__get_media_info()))
             return (await self._ws_loop(ws))
 
     @exposed_ws(0)
@@ -146,6 +164,10 @@ class MediaServer(HttpServer):
                         src.key_required = True
                     break
 
+    @exposed_ws(2)
+    async def __ws_bin_mic_handler(self, ws: WsSession, data: bytes) -> None:
+        self.__mic.feed(ws, data)
+
     @exposed_ws("start")
     async def __ws_start_handler(self, ws: WsSession, event: dict) -> None:
         try:
@@ -155,12 +177,84 @@ class MediaServer(HttpServer):
             return
         self.__start_stream(ws, m_type, m_fmt)  # TODO: Handle discard
 
-    def __get_media_info(self) -> dict:
+    @exposed_ws("audio_start")
+    async def __ws_audio_start_handler(self, ws: WsSession, event: dict) -> None:
+        if ws.kwargs["pure"]:  # Don't spoil pure data
+            return
+        error = ""
+        try:
+            fmt = valid_stripped_string(event.get("format"))
+            await self.__audio.start(
+                ws, fmt,
+                (lambda data: ws.send_bin(3, data)),
+                (lambda err: self.__send_audio_state(ws, False, err)),
+            )
+            if not ws.is_alive():
+                # The client has disconnected while we were starting the capture,
+                # so _on_ws_removed() has already passed by
+                self.__audio.stop(ws)
+                return
+        except (AudioSourceError, ValidatorError, AudioError) as ex:
+            error = tools.efmt(ex)
+        except Exception as ex:
+            error = tools.efmt(ex)
+            get_logger(0).exception("Can't start the audio for %s", ws)
+        await self.__send_audio_state(ws, (not error), error)
+
+    @exposed_ws("audio_stop")
+    async def __ws_audio_stop_handler(self, ws: WsSession, _: dict) -> None:
+        if ws.kwargs["pure"]:  # Don't spoil pure data
+            return
+        self.__audio.stop(ws)
+        await self.__send_audio_state(ws, False, "")
+
+    async def __send_audio_state(self, ws: WsSession, started: bool, error: str) -> None:
+        with contextlib.suppress(Exception):
+            await ws.send_event(self.__EV_AUDIO_STATE, {"started": started, "error": error})
+
+    @exposed_ws("mic_start")
+    async def __ws_mic_start_handler(self, ws: WsSession, event: dict) -> None:
+        if ws.kwargs["pure"]:  # Don't spoil pure data
+            return
+        error = ""
+        try:
+            fmt = valid_stripped_string(event.get("format"))
+            await self.__mic.start(ws, fmt, (lambda err: self.__send_mic_state(ws, False, err)))
+            if not ws.is_alive():
+                # The client has disconnected while we were opening the device,
+                # so _on_ws_removed() has already passed by
+                self.__mic.stop(ws)
+                return
+        except (MicError, ValidatorError, AudioError) as ex:
+            error = tools.efmt(ex)
+        except Exception as ex:
+            error = tools.efmt(ex)
+            get_logger(0).exception("Can't start the microphone for %s", ws)
+        await self.__send_mic_state(ws, (not error), error)
+
+    @exposed_ws("mic_stop")
+    async def __ws_mic_stop_handler(self, ws: WsSession, _: dict) -> None:
+        if ws.kwargs["pure"]:  # Don't spoil pure data
+            return
+        self.__mic.stop(ws)
+        await self.__send_mic_state(ws, False, "")
+
+    async def __send_mic_state(self, ws: WsSession, started: bool, error: str) -> None:
+        with contextlib.suppress(Exception):
+            await ws.send_event(self.__EV_MIC_STATE, {"started": started, "error": error})
+
+    async def __get_media_info(self) -> dict:
         info: dict = {}
         for (m_type, srcs) in self.__media.items():
             info[m_type] = {}
             for (m_fmt, src) in srcs.items():
                 info[m_type][m_fmt] = src.meta
+        audio = (await self.__audio.get_info())
+        if audio is not None:
+            info[self.__T_AUDIO] = audio
+        mic = (await self.__mic.get_info())
+        if mic is not None:
+            info[self.__T_MIC] = mic
         return info
 
     def __start_stream(self, ws: WsSession, m_type: str, m_fmt: str) -> bool:
@@ -192,6 +286,8 @@ class MediaServer(HttpServer):
         logger.info("On-Shutdown complete")
 
     def _on_ws_removed(self, ws: WsSession) -> None:
+        self.__audio.stop(ws)
+        self.__mic.stop(ws)
         for srcs in self.__media.values():
             for src in srcs.values():
                 client = src.clients.pop(ws, None)

--- a/kvmd/audio.py
+++ b/kvmd/audio.py
@@ -1,0 +1,518 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+import errno
+import ctypes
+import ctypes.util
+import functools
+
+from typing import Any
+from typing import Sequence
+
+from ctypes import c_int
+from ctypes import c_uint
+from ctypes import c_long
+from ctypes import c_ulong
+from ctypes import c_int16
+from ctypes import c_char_p
+from ctypes import c_void_p
+from ctypes import POINTER
+
+
+# =====
+class AudioError(Exception):
+    pass
+
+
+# =====
+_SND_PCM_STREAM_PLAYBACK = 0
+_SND_PCM_STREAM_CAPTURE = 1
+_SND_PCM_NONBLOCK = 1
+_SND_PCM_FORMAT_S16_LE = 2
+_SND_PCM_ACCESS_RW_INTERLEAVED = 3
+
+_OPUS_MAX_FRAME_MS = 120  # The longest possible Opus frame
+_OPUS_MAX_PACKET = 1275 * 3 + 3  # The longest possible Opus packet
+
+_OPUS_APPLICATION_AUDIO = 2049
+_OPUS_SET_BITRATE_REQUEST = 4002
+_OPUS_SET_MAX_BANDWIDTH_REQUEST = 4004
+_OPUS_SET_SIGNAL_REQUEST = 4024
+_OPUS_BANDWIDTH_FULLBAND = 1105
+_OPUS_SIGNAL_MUSIC = 3002
+
+_SPEEX_QUALITY_DESKTOP = 5
+
+
+def _load_lib(name: str, funcs: Sequence[tuple[str, Any, tuple]]) -> ctypes.CDLL:
+    path = ctypes.util.find_library(name)
+    if not path:
+        raise AudioError(f"Where is lib{name}?")
+    try:
+        lib = ctypes.CDLL(path)
+    except Exception as ex:
+        raise AudioError(f"Can't load lib{name}: {type(ex).__name__}: {ex}")
+    for (func_name, restype, argtypes) in funcs:
+        func = getattr(lib, func_name, None)
+        if func is None:
+            raise AudioError(f"Where is lib{name}.{func_name}?")
+        setattr(func, "restype", restype)
+        setattr(func, "argtypes", list(argtypes))
+    return lib
+
+
+@functools.cache
+def _load_libasound() -> ctypes.CDLL:
+    return _load_lib("asound", [
+        ("snd_pcm_open",       c_int,    (POINTER(c_void_p), c_char_p, c_int, c_int)),
+        ("snd_pcm_set_params", c_int,    (c_void_p, c_int, c_int, c_uint, c_uint, c_int, c_uint)),
+        ("snd_pcm_writei",     c_long,   (c_void_p, c_char_p, c_ulong)),
+        ("snd_pcm_readi",      c_long,   (c_void_p, c_void_p, c_ulong)),
+        ("snd_pcm_recover",    c_int,    (c_void_p, c_int, c_int)),
+        ("snd_pcm_wait",       c_int,    (c_void_p, c_int)),
+        ("snd_pcm_close",      c_int,    (c_void_p,)),
+        ("snd_strerror",       c_char_p, (c_int,)),
+
+        # The capture device requires the low-level params API: snd_pcm_set_params()
+        # asks for a small buffer, which the I2S driver can't provide
+        ("snd_pcm_hw_params_malloc",        c_int, (POINTER(c_void_p),)),
+        ("snd_pcm_hw_params_free",          None,  (c_void_p,)),
+        ("snd_pcm_hw_params_any",           c_int, (c_void_p, c_void_p)),
+        ("snd_pcm_hw_params_set_access",    c_int, (c_void_p, c_void_p, c_int)),
+        ("snd_pcm_hw_params_set_format",    c_int, (c_void_p, c_void_p, c_int)),
+        ("snd_pcm_hw_params_set_channels",  c_int, (c_void_p, c_void_p, c_uint)),
+        ("snd_pcm_hw_params_set_rate_near", c_int, (c_void_p, c_void_p, POINTER(c_uint), c_void_p)),
+        ("snd_pcm_hw_params_set_period_size_near", c_int, (c_void_p, c_void_p, POINTER(c_ulong), c_void_p)),
+        ("snd_pcm_hw_params_set_buffer_size_near", c_int, (c_void_p, c_void_p, POINTER(c_ulong))),
+        ("snd_pcm_hw_params_get_period_size", c_int, (c_void_p, POINTER(c_ulong), c_void_p)),
+        ("snd_pcm_hw_params_get_buffer_size", c_int, (c_void_p, POINTER(c_ulong))),
+        ("snd_pcm_hw_params",               c_int, (c_void_p, c_void_p)),
+        ("snd_pcm_avail_update",            c_long, (c_void_p,)),
+    ])
+
+
+@functools.cache
+def _load_libopus() -> ctypes.CDLL:
+    return _load_lib("opus", [
+        ("opus_decoder_create",  c_void_p, (c_int, c_int, POINTER(c_int))),
+        ("opus_decoder_destroy", None,     (c_void_p,)),
+        ("opus_decode",          c_int,    (c_void_p, c_char_p, c_int, POINTER(c_int16), c_int, c_int)),
+        ("opus_encoder_create",  c_void_p, (c_int, c_int, c_int, POINTER(c_int))),
+        ("opus_encoder_destroy", None,     (c_void_p,)),
+        # It's a variadic function, the value is passed by the default conversion rules
+        ("opus_encoder_ctl",     c_int,    (c_void_p, c_int)),
+        ("opus_encode",          c_int,    (c_void_p, c_char_p, c_int, c_char_p, c_int)),
+        ("opus_strerror",        c_char_p, (c_int,)),
+    ])
+
+
+@functools.cache
+def _load_libspeexdsp() -> ctypes.CDLL:
+    return _load_lib("speexdsp", [
+        ("speex_resampler_init",                    c_void_p, (c_uint, c_uint, c_uint, c_int, POINTER(c_int))),
+        ("speex_resampler_destroy",                 None,     (c_void_p,)),
+        ("speex_resampler_process_interleaved_int", c_int,    (c_void_p, c_void_p, POINTER(c_uint), c_void_p, POINTER(c_uint))),
+        ("speex_resampler_strerror",                c_char_p, (c_int,)),
+    ])
+
+
+def _alsa_error(lib: ctypes.CDLL, err: int, msg: str) -> AudioError:
+    reason = lib.snd_strerror(err)
+    return AudioError(f"{msg}: {reason.decode(errors='replace') if reason else err}")
+
+
+def _opus_error(lib: ctypes.CDLL, err: int, msg: str) -> AudioError:
+    reason = lib.opus_strerror(err)
+    return AudioError(f"{msg}: {reason.decode(errors='replace') if reason else err}")
+
+
+def _speex_error(lib: ctypes.CDLL, err: int, msg: str) -> AudioError:
+    reason = lib.speex_resampler_strerror(err)
+    return AudioError(f"{msg}: {reason.decode(errors='replace') if reason else err}")
+
+
+# =====
+class PcmPlayback:
+    # A thin wrapper around the ALSA playback device.
+    # All the methods are blocking and should be called from a thread.
+
+    # The device is opened in the non-blocking mode: if the USB host stops reading the gadget,
+    # a blocking write would hang forever and the session could never be stopped
+    __WAIT_MS = 100
+    __MAX_STALLS = 2
+
+    def __init__(self, device: str, hz: int, channels: int, latency: float) -> None:
+        self.__device = device
+        self.__hz = hz
+        self.__channels = channels
+        self.__latency = latency
+        self.__pcm: (c_void_p | None) = None
+        self.underruns = 0  # Recovered errors and dropped frames, for the diagnostics
+        self.stalled = 0
+
+    @classmethod
+    def probe(cls, device: str) -> bool:
+        try:
+            lib = _load_libasound()
+        except AudioError:
+            return False
+        pcm = c_void_p()
+        err = int(lib.snd_pcm_open(ctypes.byref(pcm), device.encode(), _SND_PCM_STREAM_PLAYBACK, 0))
+        if err == 0:
+            lib.snd_pcm_close(pcm)
+            return True
+        # The busy device is a live device too
+        return (err == -errno.EBUSY)
+
+    def open(self) -> None:
+        assert self.__pcm is None
+        lib = _load_libasound()
+        pcm = c_void_p()
+        err = int(lib.snd_pcm_open(ctypes.byref(pcm), self.__device.encode(),
+                                   _SND_PCM_STREAM_PLAYBACK, _SND_PCM_NONBLOCK))
+        if err < 0:
+            raise _alsa_error(lib, err, "Can't open PCM playback")
+        err = int(lib.snd_pcm_set_params(
+            pcm, _SND_PCM_FORMAT_S16_LE, _SND_PCM_ACCESS_RW_INTERLEAVED,
+            self.__channels, self.__hz, 1, int(self.__latency * 1000000),
+        ))
+        if err < 0:
+            lib.snd_pcm_close(pcm)
+            raise _alsa_error(lib, err, "Can't configure PCM playback")
+        self.__pcm = pcm
+
+    def write(self, data: bytes) -> None:
+        assert self.__pcm is not None
+        lib = _load_libasound()
+        frames = len(data) // (2 * self.__channels)
+        if frames == 0:
+            return
+        stalls = 0
+        while frames > 0:
+            written = int(lib.snd_pcm_writei(self.__pcm, data, frames))
+            if written == -errno.EAGAIN:
+                # The buffer is full: the host is not reading the gadget fast enough
+                ready = int(lib.snd_pcm_wait(self.__pcm, self.__WAIT_MS))
+                if ready < 0:
+                    if not self.__recover(lib, ready):
+                        raise _alsa_error(lib, ready, "Can't play PCM")
+                    return
+                if ready == 0:
+                    stalls += 1
+                    if stalls >= self.__MAX_STALLS:
+                        # The host doesn't consume the audio at all, the frame is late anyway
+                        self.stalled += 1
+                        return
+                continue
+            if written < 0:
+                # Underrun or suspend: recover the device and drop the rest of the chunk
+                if not self.__recover(lib, written):
+                    raise _alsa_error(lib, written, "Can't play PCM")
+                return
+            frames -= written
+            if frames > 0:  # Partial write
+                data = data[written * 2 * self.__channels:]
+
+    def __recover(self, lib: ctypes.CDLL, err: int) -> bool:
+        self.underruns += 1
+        return (int(lib.snd_pcm_recover(self.__pcm, err, 1)) >= 0)
+
+    def close(self) -> None:
+        if self.__pcm is not None:
+            try:
+                _load_libasound().snd_pcm_close(self.__pcm)
+            finally:
+                self.__pcm = None
+
+
+class PcmCapture:  # pylint: disable=too-many-instance-attributes
+    # A thin blocking wrapper around the ALSA capture device.
+    # All the methods are blocking and should be called from a thread.
+
+    # The device buffer is huge by default (the I2S driver offers 2.7 seconds), and we always
+    # read the oldest frame, so any stall of the reader turns into a permanent extra latency.
+    # We ask for a smaller buffer and, if the driver refuses, skip the backlog by hand.
+    __BUFFER_MS = 200
+    __MAX_LAG_MS = 100
+    __WAIT_MS = 200
+
+    def __init__(self, device: str, hz: int, channels: int, frame_ms: int) -> None:
+        self.__device = device
+        self.__hz = hz
+        self.__channels = channels
+        self.__frame_ms = frame_ms
+        self.__frames = 0
+        self.__max_lag = 0
+        self.__buf = ctypes.create_string_buffer(0)
+        self.__pcm: (c_void_p | None) = None
+        self.period = 0     # The negotiated ALSA params and the recovered errors,
+        self.buffer = 0     # ... for the diagnostics
+        self.overruns = 0
+        self.skipped = 0
+        self.stalled = 0
+
+    @classmethod
+    def probe(cls, device: str) -> bool:
+        try:
+            lib = _load_libasound()
+        except AudioError:
+            return False
+        pcm = c_void_p()
+        err = int(lib.snd_pcm_open(ctypes.byref(pcm), device.encode(), _SND_PCM_STREAM_CAPTURE, 0))
+        if err == 0:
+            lib.snd_pcm_close(pcm)
+            return True
+        # The busy device is a live device too
+        return (err == -errno.EBUSY)
+
+    def open(self) -> int:
+        # Returns the real capture rate, it can differ from the requested one
+        assert self.__pcm is None
+        lib = _load_libasound()
+        pcm = c_void_p()
+        err = int(lib.snd_pcm_open(ctypes.byref(pcm), self.__device.encode(),
+                                   _SND_PCM_STREAM_CAPTURE, _SND_PCM_NONBLOCK))
+        if err < 0:
+            raise _alsa_error(lib, err, "Can't open PCM capture")
+        try:
+            hz = self.__configure(pcm)
+        except Exception:
+            lib.snd_pcm_close(pcm)
+            raise
+        self.__frames = (hz * self.__frame_ms) // 1000
+        self.__max_lag = (hz * self.__MAX_LAG_MS) // 1000
+        self.__buf = ctypes.create_string_buffer(self.__frames * self.__channels * 2)
+        self.__pcm = pcm
+        return hz
+
+    def read(self) -> bytes:
+        # Returns the whole frame or nothing if the device was recovered after an error
+        assert self.__pcm is not None
+        lib = _load_libasound()
+        self.__skip_backlog(lib)
+        addr = ctypes.addressof(self.__buf)
+        offset = 0
+        frames = self.__frames
+        while frames > 0:
+            read = int(lib.snd_pcm_readi(self.__pcm, addr + offset, frames))
+            if read == -errno.EAGAIN:
+                # Not enough data yet, this is the normal case for the non-blocking device
+                ready = int(lib.snd_pcm_wait(self.__pcm, self.__WAIT_MS))
+                if ready == 0:
+                    # The source has stopped sending the samples at all
+                    self.stalled += 1
+                    return b""
+                if ready >= 0:
+                    continue
+                read = ready
+            if read < 0:
+                # Overrun or suspend: recover the device and drop the incomplete frame
+                self.overruns += 1
+                err = int(lib.snd_pcm_recover(self.__pcm, read, 1))
+                if err < 0:
+                    raise _alsa_error(lib, err, "Can't capture PCM")
+                return b""
+            frames -= read
+            offset += read * 2 * self.__channels
+        return self.__buf.raw
+
+    def close(self) -> None:
+        if self.__pcm is not None:
+            try:
+                _load_libasound().snd_pcm_close(self.__pcm)
+            finally:
+                self.__pcm = None
+
+    def __skip_backlog(self, lib: ctypes.CDLL) -> None:
+        # If we are late, the queued frames are the past: drop them instead of playing them late
+        avail = int(lib.snd_pcm_avail_update(self.__pcm))
+        limit = self.__frames + self.__max_lag
+        if avail < 0:
+            return  # The error will be handled by the normal read()
+        while avail >= limit + self.__frames:
+            read = int(lib.snd_pcm_readi(self.__pcm, ctypes.addressof(self.__buf), self.__frames))
+            if read <= 0:  # The error will be handled by the normal read()
+                return
+            avail -= read
+            self.skipped += 1
+
+    def __configure(self, pcm: c_void_p) -> int:
+        lib = _load_libasound()
+        params = c_void_p()
+        err = int(lib.snd_pcm_hw_params_malloc(ctypes.byref(params)))
+        if err < 0:
+            raise _alsa_error(lib, err, "Can't allocate PCM params")
+        try:
+            for (msg, func, args) in [
+                ("initialize", lib.snd_pcm_hw_params_any,          ()),
+                ("set access", lib.snd_pcm_hw_params_set_access,   (_SND_PCM_ACCESS_RW_INTERLEAVED,)),
+                ("set format", lib.snd_pcm_hw_params_set_format,   (_SND_PCM_FORMAT_S16_LE,)),
+                ("set channels", lib.snd_pcm_hw_params_set_channels, (self.__channels,)),
+            ]:
+                err = int(func(pcm, params, *args))
+                if err < 0:
+                    raise _alsa_error(lib, err, f"Can't {msg} PCM capture params")
+            hz = c_uint(self.__hz)
+            err = int(lib.snd_pcm_hw_params_set_rate_near(pcm, params, ctypes.byref(hz), None))
+            if err < 0:
+                raise _alsa_error(lib, err, "Can't set rate of PCM capture")
+
+            # Both are just a hint: the driver clamps them to what it can do,
+            # and the caller checks the result
+            period = c_ulong((hz.value * self.__frame_ms) // 1000)
+            lib.snd_pcm_hw_params_set_period_size_near(pcm, params, ctypes.byref(period), None)
+            buffer = c_ulong((hz.value * self.__BUFFER_MS) // 1000)
+            lib.snd_pcm_hw_params_set_buffer_size_near(pcm, params, ctypes.byref(buffer))
+
+            err = int(lib.snd_pcm_hw_params(pcm, params))
+            if err < 0:
+                raise _alsa_error(lib, err, "Can't apply PCM capture params")
+
+            lib.snd_pcm_hw_params_get_period_size(params, ctypes.byref(period), None)
+            lib.snd_pcm_hw_params_get_buffer_size(params, ctypes.byref(buffer))
+            self.period = period.value
+            self.buffer = buffer.value
+            return hz.value
+        finally:
+            lib.snd_pcm_hw_params_free(params)
+
+
+class OpusDecoder:
+    # The decoding itself takes tens of microseconds, so it doesn't need a thread
+
+    @classmethod
+    def probe(cls) -> bool:
+        try:
+            _load_libopus()
+        except AudioError:
+            return False
+        return True
+
+    def __init__(self, hz: int, channels: int) -> None:
+        self.__channels = channels
+        self.__frames = (hz // 1000) * _OPUS_MAX_FRAME_MS
+        self.__buf = (c_int16 * (self.__frames * channels))()
+        lib = _load_libopus()
+        err = c_int()
+        dec = lib.opus_decoder_create(hz, channels, ctypes.byref(err))
+        if not dec:
+            raise _opus_error(lib, err.value, "Can't create Opus decoder")
+        self.__dec: (c_void_p | None) = c_void_p(dec)
+
+    def decode(self, data: bytes) -> bytes:
+        assert self.__dec is not None
+        lib = _load_libopus()
+        frames = int(lib.opus_decode(self.__dec, data, len(data), self.__buf, self.__frames, 0))
+        if frames < 0:
+            raise _opus_error(lib, frames, "Can't decode Opus frame")
+        return ctypes.string_at(self.__buf, frames * self.__channels * 2)
+
+    def close(self) -> None:
+        if self.__dec is not None:
+            try:
+                _load_libopus().opus_decoder_destroy(self.__dec)
+            finally:
+                self.__dec = None
+
+
+class OpusEncoder:
+    # About 0.5 ms per stereo frame on the CM4, so it runs in the same thread as the capture
+
+    @classmethod
+    def probe(cls) -> bool:
+        try:
+            _load_libopus()
+        except AudioError:
+            return False
+        return True
+
+    def __init__(self, hz: int, channels: int, bitrate: int) -> None:
+        self.__channels = channels
+        self.__buf = ctypes.create_string_buffer(_OPUS_MAX_PACKET)
+        lib = _load_libopus()
+        err = c_int()
+        enc = lib.opus_encoder_create(hz, channels, _OPUS_APPLICATION_AUDIO, ctypes.byref(err))
+        if not enc:
+            raise _opus_error(lib, err.value, "Can't create Opus encoder")
+        self.__enc: (c_void_p | None) = c_void_p(enc)
+        # The same tuning as uStreamer uses for the WebRTC audio
+        for (request, value) in [
+            (_OPUS_SET_BITRATE_REQUEST, bitrate),
+            (_OPUS_SET_MAX_BANDWIDTH_REQUEST, _OPUS_BANDWIDTH_FULLBAND),
+            (_OPUS_SET_SIGNAL_REQUEST, _OPUS_SIGNAL_MUSIC),
+        ]:
+            code = int(lib.opus_encoder_ctl(self.__enc, request, value))
+            if code < 0:
+                self.close()
+                raise _opus_error(lib, code, "Can't configure Opus encoder")
+
+    def encode(self, data: bytes) -> bytes:
+        assert self.__enc is not None
+        lib = _load_libopus()
+        frames = len(data) // (2 * self.__channels)
+        size = int(lib.opus_encode(self.__enc, data, frames, self.__buf, _OPUS_MAX_PACKET))
+        if size < 0:
+            raise _opus_error(lib, size, "Can't encode Opus frame")
+        return self.__buf.raw[:size]
+
+    def close(self) -> None:
+        if self.__enc is not None:
+            try:
+                _load_libopus().opus_encoder_destroy(self.__enc)
+            finally:
+                self.__enc = None
+
+
+class Resampler:
+    # Converts the captured PCM to the rate that Opus can handle.
+    # The HDMI audio rate is defined by the host and can be any of 32/44.1/48/96/192 kHz.
+
+    def __init__(self, channels: int, in_hz: int, out_hz: int, in_frames: int) -> None:
+        self.__channels = channels
+        # A couple of extra frames for the rounding and the resampler's internal delay
+        self.__out_frames = (in_frames * out_hz) // in_hz + 16
+        self.__buf = ctypes.create_string_buffer(self.__out_frames * channels * 2)
+        lib = _load_libspeexdsp()
+        err = c_int()
+        res = lib.speex_resampler_init(channels, in_hz, out_hz, _SPEEX_QUALITY_DESKTOP, ctypes.byref(err))
+        if not res:
+            raise _speex_error(lib, err.value, "Can't create resampler")
+        self.__res: (c_void_p | None) = c_void_p(res)
+
+    def process(self, data: bytes) -> bytes:
+        assert self.__res is not None
+        lib = _load_libspeexdsp()
+        in_frames = c_uint(len(data) // (2 * self.__channels))
+        out_frames = c_uint(self.__out_frames)
+        err = int(lib.speex_resampler_process_interleaved_int(
+            self.__res, data, ctypes.byref(in_frames), self.__buf, ctypes.byref(out_frames),
+        ))
+        if err < 0:
+            raise _speex_error(lib, err, "Can't resample PCM")
+        return self.__buf.raw[:out_frames.value * self.__channels * 2]
+
+    def close(self) -> None:
+        if self.__res is not None:
+            try:
+                _load_libspeexdsp().speex_resampler_destroy(self.__res)
+            finally:
+                self.__res = None

--- a/testenv/Dockerfile
+++ b/testenv/Dockerfile
@@ -34,6 +34,9 @@ RUN \
 		libevent \
 		libutil-linux \
 		libbsd \
+		alsa-lib \
+		opus \
+		speexdsp \
 		python \
 		python-pip \
 		python-build \

--- a/testenv/tests/apps/media/__init__.py
+++ b/testenv/tests/apps/media/__init__.py
@@ -2,7 +2,7 @@
 #                                                                            #
 #    KVMD - The main PiKVM daemon.                                           #
 #                                                                            #
-#    Copyright (C) 2020  Maxim Devaev <mdevaev@gmail.com>                    #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
 #                                                                            #
 #    This program is free software: you can redistribute it and/or modify    #
 #    it under the terms of the GNU General Public License as published by    #
@@ -18,36 +18,3 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
 #                                                                            #
 # ========================================================================== #
-
-
-from ...clients.streamer import StreamerFormats
-from ...clients.streamer import MemsinkStreamerClient
-
-from .. import init
-
-from .audio import AudioSource
-
-from .mic import MicSink
-
-from .server import MediaServer
-
-
-# =====
-def main() -> None:
-    config = init(
-        prog="kvmd-media",
-        description="The media proxy",
-        check_run=True,
-    ).config.media
-
-    def make_streamer(name: str, fmt: int) -> (MemsinkStreamerClient | None):
-        if getattr(config.memsink, name).sink:
-            return MemsinkStreamerClient(fmt, **getattr(config.memsink, name)._unpack())
-        return None
-
-    MediaServer(
-        h264_streamer=make_streamer("h264", StreamerFormats.H264),
-        jpeg_streamer=make_streamer("jpeg", StreamerFormats.JPEG),
-        audio=AudioSource(**config.audio._unpack()),
-        mic=MicSink(**config.mic._unpack()),
-    ).run(**config.server._unpack())

--- a/testenv/tests/apps/media/test_audio.py
+++ b/testenv/tests/apps/media/test_audio.py
@@ -1,0 +1,438 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+import asyncio
+import time
+import threading
+
+import pytest
+
+from kvmd.audio import AudioError
+from kvmd.apps.media import audio as audio_module
+from kvmd.apps.media.audio import AudioSourceError
+from kvmd.apps.media.audio import AudioSource
+
+
+# =====
+class _FakeCapture:  # pylint: disable=too-many-instance-attributes
+    last: ("_FakeCapture | None") = None
+    count: int = 0
+    available: bool = True
+    fail_open: bool = False
+    fail_read: bool = False
+    empty_reads: int = 0
+    real_hz: int = AudioSource.HZ
+
+    @classmethod
+    def probe(cls, device: str) -> bool:
+        _ = device
+        return cls.available
+
+    def __init__(self, device: str, hz: int, channels: int, frame_ms: int) -> None:
+        self.device = device
+        self.hz = hz
+        self.channels = channels
+        self.frame_ms = frame_ms
+        self.opened = False
+        self.reads = 0
+        self.period = 960
+        self.buffer = 9600
+        self.overruns = 0
+        self.skipped = 0
+        self.stalled = 0
+        _FakeCapture.last = self
+        _FakeCapture.count += 1
+
+    def open(self) -> int:
+        if _FakeCapture.fail_open:
+            raise AudioError("Can't open PCM capture: No such device")
+        self.opened = True
+        return _FakeCapture.real_hz
+
+    def read(self) -> bytes:
+        assert self.opened
+        time.sleep(0.01)  # Emulate the real-time capture
+        if _FakeCapture.fail_read:
+            raise AudioError("Can't capture PCM: Input/output error")
+        if _FakeCapture.empty_reads > 0:
+            # The device was recovered after an overrun or stalled
+            _FakeCapture.empty_reads -= 1
+            return b""
+        self.reads += 1
+        return b"RAW%04d" % (self.reads,)  # The number makes the dropped frames visible
+
+    def close(self) -> None:
+        self.opened = False
+
+
+class _FakeEncoder:
+    last: ("_FakeEncoder | None") = None
+    available: bool = True
+    fail_encode: bool = False
+    fail_init: bool = False
+    fails: int = 0
+    thread: int = 0
+
+    @classmethod
+    def probe(cls) -> bool:
+        return cls.available
+
+    def __init__(self, hz: int, channels: int, bitrate: int) -> None:
+        _FakeEncoder.thread = threading.get_ident()
+        if _FakeEncoder.fail_init:
+            raise AudioError("Can't create Opus encoder: no memory")
+        self.hz = hz
+        self.channels = channels
+        self.bitrate = bitrate
+        self.calls = 0
+        self.closed = False
+        _FakeEncoder.last = self
+
+    def encode(self, data: bytes) -> bytes:
+        if _FakeEncoder.fail_encode:
+            _FakeEncoder.fails += 1
+            raise AudioError("Can't encode Opus frame: invalid argument")
+        self.calls += 1
+        return b"E" + data
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeResampler:
+    last: ("_FakeResampler | None") = None
+    thread: int = 0
+
+    def __init__(self, channels: int, in_hz: int, out_hz: int, in_frames: int) -> None:
+        _FakeResampler.thread = threading.get_ident()
+        self.channels = channels
+        self.in_hz = in_hz
+        self.out_hz = out_hz
+        self.in_frames = in_frames
+        self.closed = False
+        _FakeResampler.last = self
+
+    def process(self, data: bytes) -> bytes:
+        return b"R" + data
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(name="src")
+def _src_fixture(monkeypatch: pytest.MonkeyPatch) -> AudioSource:
+    monkeypatch.setattr(audio_module, "PcmCapture", _FakeCapture)
+    monkeypatch.setattr(audio_module, "OpusEncoder", _FakeEncoder)
+    monkeypatch.setattr(audio_module, "Resampler", _FakeResampler)
+    _FakeCapture.last = None
+    _FakeCapture.count = 0
+    _FakeCapture.available = True
+    _FakeCapture.fail_open = False
+    _FakeCapture.fail_read = False
+    _FakeCapture.empty_reads = 0
+    _FakeCapture.real_hz = AudioSource.HZ
+    _FakeEncoder.last = None
+    _FakeEncoder.available = True
+    _FakeEncoder.fail_encode = False
+    _FakeEncoder.fail_init = False
+    _FakeEncoder.fails = 0
+    _FakeEncoder.thread = 0
+    _FakeResampler.last = None
+    _FakeResampler.thread = 0
+    # The retries are slow by design, the tests don't need to wait for the real timeouts
+    monkeypatch.setattr(AudioSource, "_AudioSource__ERROR_DELAY", 0.05)
+    monkeypatch.setattr(AudioSource, "_AudioSource__REPORT_AFTER", 2)
+    # Without the TC358743 the source always uses the default rate
+    return AudioSource("plughw:tc358743,0", "")
+
+
+async def _wait(func, timeout: float=5.0) -> bool:  # type: ignore
+    for _ in range(int(timeout / 0.01)):
+        if func():
+            return True
+        await asyncio.sleep(0.01)
+    return False
+
+
+def _payload(frame: bytes) -> bytes:
+    return frame[1:]  # The first byte is the discontinuity flag
+
+
+def _gap(frame: bytes) -> bool:
+    return bool(frame[0] & 1)
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.frames: list[bytes] = []
+        self.errors: list[str] = []
+
+    async def on_frame(self, data: bytes) -> None:
+        self.frames.append(data)
+
+    async def on_error(self, error: str) -> None:
+        self.errors.append(error)
+
+
+# =====
+@pytest.mark.asyncio
+async def test_ok__audio__opus(src: AudioSource) -> None:
+    client = _Client()
+    await src.start(client, "opus", client.on_frame, client.on_error)
+    assert (await _wait(lambda: len(client.frames) >= 2))
+    assert _payload(client.frames[0]).startswith(b"ERAW")
+
+    cap = _FakeCapture.last
+    assert cap is not None
+    assert (cap.device, cap.hz, cap.channels, cap.frame_ms) \
+        == ("plughw:tc358743,0", AudioSource.HZ, AudioSource.CHANNELS, AudioSource.FRAME_MS)
+    assert _FakeResampler.last is None  # The rate matches, no resampling needed
+
+    src.stop(client)
+    enc = _FakeEncoder.last
+    assert enc is not None
+    assert (await _wait(lambda: enc.closed))  # The encoder is closed after the device
+    assert (await _wait(lambda: not cap.opened))
+
+
+@pytest.mark.asyncio
+async def test_ok__audio__pcm(src: AudioSource) -> None:
+    client = _Client()
+    await src.start(client, "pcm", client.on_frame, client.on_error)
+    assert (await _wait(lambda: len(client.frames) >= 2))
+    assert _payload(client.frames[0]).startswith(b"RAW")
+    src.stop(client)
+    cap = _FakeCapture.last
+    assert cap is not None
+    assert (await _wait(lambda: not cap.opened))
+
+
+@pytest.mark.asyncio
+async def test_ok__audio__shared(src: AudioSource) -> None:
+    (client1, client2) = (_Client(), _Client())
+    await src.start(client1, "opus", client1.on_frame, client1.on_error)
+    await src.start(client2, "pcm", client2.on_frame, client2.on_error)
+    assert (await _wait(lambda: len(client1.frames) >= 3 and len(client2.frames) >= 3))
+    assert _FakeCapture.count == 1  # The device is captured once for all the clients
+    assert _payload(client1.frames[0]).startswith(b"ERAW")
+    assert _payload(client2.frames[0]).startswith(b"RAW")
+
+    enc = _FakeEncoder.last
+    assert enc is not None
+    src.stop(client1)  # The rest of the clients keep the capture alive
+    count = len(client2.frames)
+    calls = enc.calls
+    assert (await _wait(lambda: len(client2.frames) > count + 2))
+    assert enc.calls == calls  # Nobody needs the Opus anymore
+
+    cap = _FakeCapture.last
+    assert cap is not None
+    assert cap.opened
+    src.stop(client2)
+    assert (await _wait(lambda: not cap.opened))
+
+
+@pytest.mark.asyncio
+async def test_ok__audio__resampling(src: AudioSource) -> None:
+    _FakeCapture.real_hz = 44100  # The host sends the CD-quality audio
+    client = _Client()
+    await src.start(client, "opus", client.on_frame, client.on_error)
+    assert (await _wait(lambda: len(client.frames) >= 2))
+    assert _payload(client.frames[0]).startswith(b"ERRAW")  # Resampled, then encoded
+
+    res = _FakeResampler.last
+    assert res is not None
+    assert (res.channels, res.in_hz, res.out_hz) == (AudioSource.CHANNELS, 44100, AudioSource.HZ)
+
+    src.stop(client)
+    assert (await _wait(lambda: res.closed))
+
+
+@pytest.mark.asyncio
+async def test_fail__audio__capture(src: AudioSource) -> None:
+    client = _Client()
+    await src.start(client, "pcm", client.on_frame, client.on_error)
+    assert (await _wait(lambda: len(client.frames) >= 1))
+    _FakeCapture.fail_read = True
+
+    assert (await _wait(lambda: len(client.errors) > 0))
+    assert "Input/output error" in client.errors[0]
+    src.stop(client)
+
+
+@pytest.mark.asyncio
+async def test_fail__audio__format(src: AudioSource) -> None:
+    client = _Client()
+    with pytest.raises(AudioSourceError):
+        await src.start(client, "mp3", client.on_frame, client.on_error)
+
+    _FakeEncoder.available = False  # No libopus on the system
+    with pytest.raises(AudioSourceError):
+        await src.start(client, "opus", client.on_frame, client.on_error)
+
+
+@pytest.mark.asyncio
+async def test_ok__audio__info(src: AudioSource) -> None:
+    info = (await src.get_info())
+    assert info is not None
+    assert info["formats"] == ["opus", "pcm"]
+    assert (info["hz"], info["channels"]) == (AudioSource.HZ, AudioSource.CHANNELS)
+
+    _FakeEncoder.available = False  # No libopus on the system
+    info = (await src.get_info())
+    assert info is not None
+    assert info["formats"] == ["pcm"]
+
+    _FakeCapture.available = False  # No HDMI capture device
+    assert (await src.get_info()) is None
+
+
+@pytest.mark.asyncio
+async def test_fail__audio__disabled() -> None:
+    src = AudioSource("", "")
+    assert (await src.get_info()) is None
+    client = _Client()
+    with pytest.raises(AudioSourceError):
+        await src.start(client, "opus", client.on_frame, client.on_error)
+
+
+@pytest.mark.asyncio
+async def test_ok__audio__queue_trim(src: AudioSource) -> None:
+    # The stalled client gets the recent audio, not the half-second-old backlog
+    gate = asyncio.Event()
+
+    class _SlowClient(_Client):
+        async def on_frame(self, data: bytes) -> None:
+            await gate.wait()
+            self.frames.append(data)
+
+    (slow, fast) = (_SlowClient(), _Client())
+    await src.start(slow, "pcm", slow.on_frame, slow.on_error)
+    await src.start(fast, "pcm", fast.on_frame, fast.on_error)
+    assert (await _wait(lambda: len(fast.frames) >= 40))  # The queue is long overflowed
+    gate.set()
+    assert (await _wait(lambda: len(slow.frames) >= 3))
+
+    # The first frame was already taken from the queue by the sender before the stall,
+    # the next one must be a recent frame and not the rest of the half-second backlog,
+    # and it must be marked as a discontinuity for the client
+    (first, second) = (int(_payload(slow.frames[0])[3:]), int(_payload(slow.frames[1])[3:]))
+    assert second - first > 10
+    assert _gap(slow.frames[1])
+    assert not _gap(slow.frames[0])
+    src.stop(slow)
+    src.stop(fast)
+
+
+@pytest.mark.asyncio
+async def test_ok__audio__broken_frame(src: AudioSource, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(AudioSource, "_AudioSource__MAX_BROKEN", 4)
+    client = _Client()
+    await src.start(client, "opus", client.on_frame, client.on_error)
+    assert (await _wait(lambda: len(client.frames) >= 2))
+    enc = _FakeEncoder.last
+    assert enc is not None
+
+    _FakeEncoder.fail_encode = True  # A few broken frames don't restart the device
+    assert (await _wait(lambda: _FakeEncoder.fails >= 2))
+    _FakeEncoder.fail_encode = False
+    count = len(client.frames)
+    assert (await _wait(lambda: len(client.frames) > count + 2))
+    assert _FakeCapture.count == 1
+    assert not client.errors
+
+    _FakeEncoder.fail_encode = True  # ... but the permanent error does
+    assert (await _wait(lambda: _FakeCapture.count > 1))
+    assert (await _wait(lambda: len(client.errors) > 0))
+    assert "invalid argument" in client.errors[0]
+    src.stop(client)
+
+
+@pytest.mark.asyncio
+async def test_ok__audio__empty_frames(src: AudioSource) -> None:
+    # A recovered overrun gives no data, but the capture goes on
+    client = _Client()
+    await src.start(client, "pcm", client.on_frame, client.on_error)
+    assert (await _wait(lambda: len(client.frames) >= 1))
+    _FakeCapture.empty_reads = 5
+    count = len(client.frames)
+    assert (await _wait(lambda: len(client.frames) > count + 2))
+    assert _FakeCapture.count == 1  # The device was not reopened
+    assert not client.errors
+    # ... and the empty reads were not sent to the client as empty frames
+    assert all(_payload(frame).startswith(b"RAW") for frame in client.frames)
+    src.stop(client)
+
+
+@pytest.mark.asyncio
+async def test_ok__audio__transient_error(src: AudioSource) -> None:
+    # The device is busy for a moment when the user switches the video mode,
+    # and the client should not be bothered with that
+    _FakeCapture.fail_open = True
+    client = _Client()
+    await src.start(client, "pcm", client.on_frame, client.on_error)
+    assert (await _wait(lambda: _FakeCapture.count >= 1))
+    _FakeCapture.fail_open = False
+    assert (await _wait(lambda: len(client.frames) >= 2))
+    assert not client.errors
+
+    # ... but a device that stays broken is reported
+    _FakeCapture.fail_open = True
+    _FakeCapture.fail_read = True
+    assert (await _wait(lambda: len(client.errors) > 0))
+    src.stop(client)
+
+
+@pytest.mark.asyncio
+async def test_ok__audio__codecs_in_thread(src: AudioSource) -> None:
+    # Both of them load their libraries on the first use, and that runs ldconfig,
+    # so they must not be constructed on the event loop
+    _FakeCapture.real_hz = 44100
+    client = _Client()
+    await src.start(client, "opus", client.on_frame, client.on_error)
+    assert (await _wait(lambda: len(client.frames) >= 2))
+    assert _FakeResampler.thread not in (0, threading.get_ident())
+    assert _FakeEncoder.thread not in (0, threading.get_ident())
+    src.stop(client)
+
+
+@pytest.mark.asyncio
+async def test_ok__audio__codecs_cleanup(src: AudioSource) -> None:
+    # The resampler is made first, it must not leak when the encoder fails
+    _FakeCapture.real_hz = 44100
+    _FakeEncoder.fail_init = True
+    client = _Client()
+    await src.start(client, "opus", client.on_frame, client.on_error)
+    assert (await _wait(lambda: _FakeResampler.last is not None))
+    res = _FakeResampler.last
+    assert res is not None
+    assert (await _wait(lambda: res.closed))
+    src.stop(client)
+
+
+@pytest.mark.asyncio
+async def test_ok__audio__no_opus_logged_once(src: AudioSource, caplog: pytest.LogCaptureFixture) -> None:
+    _FakeEncoder.available = False  # No libopus on the system
+    with caplog.at_level("ERROR"):
+        for _ in range(3):  # Every client connect asks for the info
+            assert (await src.get_info()) is not None
+    assert len([rec for rec in caplog.records if "No libopus" in rec.message]) == 1

--- a/testenv/tests/apps/media/test_mic.py
+++ b/testenv/tests/apps/media/test_mic.py
@@ -1,0 +1,328 @@
+# ========================================================================== #
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+# ========================================================================== #
+
+
+import asyncio
+import threading
+
+import pytest
+
+from kvmd.audio import AudioError
+from kvmd.apps.media import mic as mic_module
+from kvmd.apps.media.mic import MicError
+from kvmd.apps.media.mic import MicBusyError
+from kvmd.apps.media.mic import MicSink
+
+
+# =====
+class _FakePcm:  # pylint: disable=too-many-instance-attributes
+    last: ("_FakePcm | None") = None
+    fail_open: bool = False
+    available: bool = True
+    gate: ("threading.Event | None") = None
+
+    @classmethod
+    def probe(cls, device: str) -> bool:
+        _ = device
+        return cls.available
+
+    def __init__(self, device: str, hz: int, channels: int, latency: float) -> None:
+        self.device = device
+        self.hz = hz
+        self.channels = channels
+        self.latency = latency
+        self.opened = False
+        self.written: list[bytes] = []
+        self.fail_write = False
+        self.underruns = 0
+        self.stalled = 0
+        _FakePcm.last = self
+
+    def open(self) -> None:
+        if _FakePcm.fail_open:
+            raise AudioError("Can't open PCM playback: No such device")
+        if _FakePcm.gate is not None:
+            _FakePcm.gate.wait(5)  # Bounded, so a failed test can't hang the runner
+        self.opened = True
+
+    def write(self, data: bytes) -> None:
+        assert self.opened
+        if self.fail_write:
+            raise AudioError("Can't play PCM: Broken pipe")
+        self.written.append(data)
+
+    def close(self) -> None:
+        self.opened = False
+
+
+class _FakeDecoder:
+    available: bool = True
+    fail_decode: bool = False
+
+    @classmethod
+    def probe(cls) -> bool:
+        return cls.available
+
+    def __init__(self, hz: int, channels: int) -> None:
+        self.hz = hz
+        self.channels = channels
+        self.closed = False
+
+    def decode(self, data: bytes) -> bytes:
+        if _FakeDecoder.fail_decode:
+            raise AudioError("Can't decode Opus frame: corrupted stream")
+        return b"D" + data
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(name="sink")
+def _sink_fixture(monkeypatch: pytest.MonkeyPatch) -> MicSink:
+    monkeypatch.setattr(mic_module, "PcmPlayback", _FakePcm)
+    monkeypatch.setattr(mic_module, "OpusDecoder", _FakeDecoder)
+    _FakePcm.last = None
+    _FakePcm.fail_open = False
+    _FakePcm.available = True
+    _FakePcm.gate = None
+    _FakeDecoder.available = True
+    _FakeDecoder.fail_decode = False
+    return MicSink("plughw:UAC2Gadget,0", 0.1)
+
+
+async def _wait(func, timeout: float=5.0) -> bool:  # type: ignore
+    for _ in range(int(timeout / 0.01)):
+        if func():
+            return True
+        await asyncio.sleep(0.01)
+    return False
+
+
+async def _noop(error: str) -> None:
+    _ = error
+
+
+# =====
+@pytest.mark.asyncio
+async def test_ok__mic__opus(sink: MicSink) -> None:
+    ws = object()
+    await sink.start(ws, "opus", _noop)
+    pcm = _FakePcm.last
+    assert pcm is not None
+    assert pcm.opened
+    assert (pcm.device, pcm.hz, pcm.channels) == ("plughw:UAC2Gadget,0", MicSink.HZ, MicSink.CHANNELS)
+
+    sink.feed(ws, b"123")
+    assert (await _wait(lambda: pcm.written == [b"D123"]))
+
+    await sink.start(ws, "opus", _noop)  # The same client doesn't restart the playback
+    assert _FakePcm.last is pcm
+
+    sink.stop(ws)
+    assert (await _wait(lambda: not pcm.opened))
+
+
+@pytest.mark.asyncio
+async def test_ok__mic__pcm(sink: MicSink) -> None:
+    ws = object()
+    await sink.start(ws, "pcm", _noop)
+    pcm = _FakePcm.last
+    assert pcm is not None
+
+    sink.feed(ws, b"123")
+    assert (await _wait(lambda: pcm.written == [b"123"]))
+
+    sink.stop(ws)
+    assert (await _wait(lambda: not pcm.opened))
+
+
+@pytest.mark.asyncio
+async def test_fail__mic__busy(sink: MicSink) -> None:
+    (ws1, ws2) = (object(), object())
+    await sink.start(ws1, "opus", _noop)
+    pcm = _FakePcm.last
+    assert pcm is not None
+
+    with pytest.raises(MicBusyError):
+        await sink.start(ws2, "opus", _noop)
+
+    sink.feed(ws2, b"123")  # The foreign client can't feed the playback
+    sink.stop(ws2)  # ... and can't stop it too
+    await asyncio.sleep(0.1)
+    assert pcm.written == []
+    assert pcm.opened
+
+    sink.stop(ws1)
+    assert (await _wait(lambda: not pcm.opened))
+
+    await sink.start(ws2, "opus", _noop)  # The mic is free now
+    assert _FakePcm.last is not pcm
+    sink.stop(ws2)
+
+
+@pytest.mark.asyncio
+async def test_fail__mic__format(sink: MicSink) -> None:
+    with pytest.raises(MicError):
+        await sink.start(object(), "mp3", _noop)
+
+
+@pytest.mark.asyncio
+async def test_fail__mic__no_device(sink: MicSink) -> None:
+    _FakePcm.fail_open = True
+    with pytest.raises(AudioError):
+        await sink.start(object(), "opus", _noop)
+    _FakePcm.fail_open = False
+    await sink.start(object(), "opus", _noop)  # The failed start doesn't lock the mic
+
+
+@pytest.mark.asyncio
+async def test_fail__mic__playback(sink: MicSink) -> None:
+    errors: list[str] = []
+
+    async def on_error(error: str) -> None:
+        errors.append(error)
+
+    ws = object()
+    await sink.start(ws, "pcm", on_error)
+    pcm = _FakePcm.last
+    assert pcm is not None
+    pcm.fail_write = True
+
+    sink.feed(ws, b"123")
+    assert (await _wait(lambda: len(errors) > 0))
+    assert "Broken pipe" in errors[0]
+    assert not pcm.opened
+
+    await sink.start(object(), "pcm", _noop)  # The broken session doesn't lock the mic
+
+
+@pytest.mark.asyncio
+async def test_ok__mic__info(sink: MicSink) -> None:
+    info = (await sink.get_info())
+    assert info is not None
+    assert info["formats"] == ["opus", "pcm"]
+    assert (info["hz"], info["channels"]) == (MicSink.HZ, MicSink.CHANNELS)
+
+    _FakeDecoder.available = False  # No libopus on the system
+    info = (await sink.get_info())
+    assert info is not None
+    assert info["formats"] == ["pcm"]
+
+    _FakePcm.available = False  # No USB audio gadget
+    assert (await sink.get_info()) is None
+
+
+@pytest.mark.asyncio
+async def test_fail__mic__disabled() -> None:
+    sink = MicSink("", 0.1)
+    assert (await sink.get_info()) is None
+    with pytest.raises(MicError):
+        await sink.start(object(), "opus", _noop)
+
+
+@pytest.mark.asyncio
+async def test_ok__mic__broken_frame(sink: MicSink) -> None:
+    # A corrupted frame is skipped, the session goes on
+    ws = object()
+    await sink.start(ws, "opus", _noop)
+    pcm = _FakePcm.last
+    assert pcm is not None
+
+    _FakeDecoder.fail_decode = True
+    sink.feed(ws, b"123")
+    await asyncio.sleep(0.1)
+    assert pcm.written == []
+    assert pcm.opened  # Not a reason to stop the playback
+
+    _FakeDecoder.fail_decode = False
+    sink.feed(ws, b"456")
+    assert (await _wait(lambda: pcm.written == [b"D456"]))
+    sink.stop(ws)
+
+
+@pytest.mark.asyncio
+async def test_ok__mic__bad_frames(sink: MicSink) -> None:
+    # The empty frame is the internal stop signal, the client can't send it;
+    # a huge one would occupy the device for its whole duration
+    ws = object()
+    await sink.start(ws, "pcm", _noop)
+    pcm = _FakePcm.last
+    assert pcm is not None
+
+    sink.feed(ws, b"")
+    sink.feed(ws, b"x" * 100500)
+    await asyncio.sleep(0.1)
+    assert pcm.written == []
+    assert pcm.opened
+
+    sink.feed(ws, b"123")
+    assert (await _wait(lambda: pcm.written == [b"123"]))
+    sink.stop(ws)
+
+
+@pytest.mark.asyncio
+async def test_ok__mic__queue_trim(sink: MicSink) -> None:
+    # The client that sends the audio faster than the real time loses the oldest frames
+    ws = object()
+    await sink.start(ws, "pcm", _noop)
+    pcm = _FakePcm.last
+    assert pcm is not None
+
+    # The playing task can't run between the feeds, so the queue overflows
+    for index in range(100):
+        sink.feed(ws, b"%03d" % (index,))
+
+    assert (await _wait(lambda: len(pcm.written) >= 3))
+    await asyncio.sleep(0.1)
+    assert len(pcm.written) < 100  # Something was dropped
+    assert pcm.written[-1] == b"099"  # ... but the recent audio is kept
+    sink.stop(ws)
+
+
+@pytest.mark.asyncio
+async def test_fail__mic__format_change(sink: MicSink) -> None:
+    ws = object()
+    await sink.start(ws, "opus", _noop)
+    with pytest.raises(MicError):
+        await sink.start(ws, "pcm", _noop)  # The decoder is already made
+    sink.stop(ws)
+
+
+@pytest.mark.asyncio
+async def test_ok__mic__cancelled_open(sink: MicSink) -> None:
+    # The cancellation arrives when the device is already open: it must be closed,
+    # otherwise the microphone stays busy for everybody until the service restarts
+    _FakePcm.gate = threading.Event()
+    task = asyncio.create_task(sink.start(object(), "pcm", _noop))
+    assert (await _wait(lambda: _FakePcm.last is not None))
+    task.cancel()
+    _FakePcm.gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    pcm = _FakePcm.last
+    assert pcm is not None
+    assert (await _wait(lambda: not pcm.opened))  # Closed, not leaked
+
+    _FakePcm.gate = None
+    ws = object()
+    await sink.start(ws, "pcm", _noop)  # ... so the device is free for the next client
+    sink.stop(ws)

--- a/web/kvm/index.html
+++ b/web/kvm/index.html
@@ -424,6 +424,22 @@
                   <select class="small" id="stream-mic-selector" style="width: 90%;" disabled></select>
                 </td>
               </tr>
+              <tr class="feature-disabled" id="stream-mic-raw">
+                <td>Raw microphone:</td>
+                <td>
+                      <div class="switch-box">
+                        <input disabled type="checkbox" id="stream-mic-raw-switch">
+                        <label for="stream-mic-raw-switch"><span class="switch-inner"></span><span class="switch"></span></label>
+                      </div>
+                </td>
+                <td class="tip">No noise suppression and no auto gain</td>
+              </tr>
+              <tr class="feature-disabled" id="stream-mic-level">
+                <td>Mic level:</td>
+                <td class="slider" colspan="2">
+                  <div class="progress" id="stream-mic-level-progress"><span class="progress-value" id="stream-mic-level-value"></span></div>
+                </td>
+              </tr>
               <tr class="feature-disabled" id="stream-camera">
                 <td>Camera:</td>
                 <td>

--- a/web/kvm/navbar-system.pug
+++ b/web/kvm/navbar-system.pug
@@ -126,6 +126,15 @@ li.right#system-dropdown
 					td Microphone:
 					td #[+menu_switch("stream-mic-switch", false, false)]
 					td #[select.small#stream-mic-selector(style="width: 90%;" disabled)]
+				tr.feature-disabled#stream-mic-raw
+					td Raw microphone:
+					td #[+menu_switch("stream-mic-raw-switch", false, false)]
+					td.tip No noise suppression and no auto gain
+				tr.feature-disabled#stream-mic-level
+					td Mic level:
+					td.slider(colspan="2")
+						.progress#stream-mic-level-progress
+							span.progress-value#stream-mic-level-value
 				tr.feature-disabled#stream-camera
 					td Camera:
 					td #[+menu_switch("stream-camera-switch", false, false)]

--- a/web/share/js/kvm/mic_level.js
+++ b/web/share/js/kvm/mic_level.js
@@ -27,8 +27,9 @@
 import {tools, $} from "../tools.js";
 
 
-// The microphone level meter. The mic itself belongs to Janus, so the meter
-// just listens to the track that is being sent to the host.
+// The microphone level meter. It can either be fed with the captured samples
+// (the direct mode encodes them itself) or attached to a track that somebody
+// else is sending (the WebRTC mode gives the microphone to Janus).
 export function MicLevel() {
 	var self = this;
 
@@ -38,7 +39,7 @@ export function MicLevel() {
 	var __RELEASE = 2; // The meter falls this many dB per frame, 100dB/s
 	var __CLIP = 0.99; // Everything above is a clipped sample
 	var __CLIP_HOLD = 40; // ... and the warning stays for 0.8s
-	var __PERIOD = 20; // The meter is updated 50 times per second
+	var __PERIOD = 20; // Every audio frame, so nothing is skipped by the rounding
 
 	var __sum = 0;
 	var __count = 0;
@@ -56,7 +57,15 @@ export function MicLevel() {
 
 	/************************************************************************/
 
+	self.feed = function(samples) {
+		// The direct mode has the samples in hand, no extra graph is needed:
+		// it calls us once per 20ms frame, which is exactly the meter's period
+		__accumulate(samples);
+		__update();
+	};
+
 	self.attach = function(track) {
+		// The WebRTC mode doesn't touch the samples, so we listen to the track
 		self.detach();
 		try {
 			__ctx = new AudioContext();

--- a/web/share/js/kvm/mic_level.js
+++ b/web/share/js/kvm/mic_level.js
@@ -1,0 +1,187 @@
+/*****************************************************************************
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+*****************************************************************************/
+
+
+
+"use strict";
+
+
+import {tools, $} from "../tools.js";
+
+
+// The microphone level meter. The mic itself belongs to Janus, so the meter
+// just listens to the track that is being sent to the host.
+export function MicLevel() {
+	var self = this;
+
+	/************************************************************************/
+
+	var __FLOOR = -60; // The bottom of the scale, dBFS
+	var __RELEASE = 2; // The meter falls this many dB per frame, 100dB/s
+	var __CLIP = 0.99; // Everything above is a clipped sample
+	var __CLIP_HOLD = 40; // ... and the warning stays for 0.8s
+	var __PERIOD = 20; // The meter is updated 50 times per second
+
+	var __sum = 0;
+	var __count = 0;
+	var __peak = 0;
+
+	var __level_db = __FLOOR;
+	var __clipped = 0;
+
+	var __ctx = null;
+	var __resuming = false;
+	var __src = null;
+	var __analyser = null;
+	var __buf = null;
+	var __timer = null;
+
+	/************************************************************************/
+
+	self.attach = function(track) {
+		self.detach();
+		try {
+			__ctx = new AudioContext();
+			// The source must be kept referenced, otherwise it can be garbage collected
+			__src = __ctx.createMediaStreamSource(new MediaStream([track]));
+			__analyser = __ctx.createAnalyser();
+			// 1024 samples is about 21ms at 48kHz: the same window the direct mode
+			// measures, so both modes react to the sound in the same way
+			__analyser.fftSize = 1024;
+			__buf = new Float32Array(__analyser.fftSize);
+			__src.connect(__analyser); // Not connected to the destination: nothing is played
+			__timer = setInterval(__poll, __PERIOD);
+			__poll();
+		} catch (err) {
+			tools.error("MicLevel: Can't attach to the track:", err);
+			self.detach();
+		}
+	};
+
+	self.detach = function() {
+		if (__timer !== null) {
+			clearInterval(__timer);
+			__timer = null;
+		}
+		for (let close of [
+			() => { if (__src !== null) { __src.disconnect(); } },
+			() => { if (__analyser !== null) { __analyser.disconnect(); } },
+			() => { if (__ctx !== null) { __ctx.close(); } },
+		]) {
+			try {
+				close();
+			} catch (err) {
+				tools.error("MicLevel: Can't detach from the track:", err);
+			}
+		}
+		__resuming = false;
+		__src = null;
+		__analyser = null;
+		__buf = null;
+		__ctx = null;
+		self.reset();
+	};
+
+	self.reset = function() {
+		__sum = 0;
+		__count = 0;
+		__peak = 0;
+		__level_db = __FLOOR;
+		__clipped = 0;
+		__draw();
+	};
+
+	/************************************************************************/
+
+	var __poll = function() {
+		if (__ctx === null) {
+			return;
+		}
+		if (__ctx.state !== "running") {
+			if (!__resuming) { // One pending resume is enough
+				__resuming = true;
+				__ctx.resume().catch(function(err) {
+					tools.error("MicLevel: Can't resume the context:", err);
+				}).finally(function() {
+					__resuming = false;
+				});
+			}
+			return;
+		}
+		__analyser.getFloatTimeDomainData(__buf);
+		__accumulate(__buf);
+		__update();
+	};
+
+	var __accumulate = function(samples) {
+		for (let index = 0; index < samples.length; ++index) {
+			let value = Math.abs(samples[index]);
+			__sum += value * value;
+			if (value > __peak) {
+				__peak = value;
+			}
+		}
+		__count += samples.length;
+	};
+
+	var __update = function() {
+		if (__count === 0) {
+			return;
+		}
+		let rms = Math.sqrt(__sum / __count);
+		let db = (rms > 0 ? 20 * Math.log10(rms) : __FLOOR);
+		// The level jumps up instantly and falls smoothly, like any audio meter
+		__level_db = Math.max(db, __level_db - __RELEASE);
+		if (__peak >= __CLIP) {
+			__clipped = __CLIP_HOLD;
+		} else if (__clipped > 0) {
+			__clipped -= 1;
+		}
+		__sum = 0;
+		__count = 0;
+		__peak = 0;
+		__draw();
+	};
+
+	var __percent = function(db) {
+		return Math.max(0, Math.min(100, (db - __FLOOR) / -__FLOOR * 100));
+	};
+
+	var __styled = false;
+
+	var __draw = function() {
+		if (!__styled) {
+			__styled = true;
+			// The bar jumps between the updates by default, this blends the steps
+			// without making the meter lag behind the sound
+			$("stream-mic-level-progress").querySelector(".progress-value")
+				.style.transition = `width ${__PERIOD}ms linear`;
+		}
+		let percent = __percent(__level_db);
+		let label = "";
+		if (__clipped > 0) {
+			label = "Clipping!";
+		} else if (percent > 0) {
+			label = `${Math.round(__level_db)} dB`;
+		}
+		tools.progress.setValue($("stream-mic-level-progress"), label, percent);
+	};
+}

--- a/web/share/js/kvm/mic_worklet.js
+++ b/web/share/js/kvm/mic_worklet.js
@@ -1,8 +1,8 @@
-# ========================================================================== #
+/*****************************************************************************
 #                                                                            #
 #    KVMD - The main PiKVM daemon.                                           #
 #                                                                            #
-#    Copyright (C) 2020  Maxim Devaev <mdevaev@gmail.com>                    #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
 #                                                                            #
 #    This program is free software: you can redistribute it and/or modify    #
 #    it under the terms of the GNU General Public License as published by    #
@@ -17,37 +17,38 @@
 #    You should have received a copy of the GNU General Public License       #
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
 #                                                                            #
-# ========================================================================== #
+*****************************************************************************/
 
 
-from ...clients.streamer import StreamerFormats
-from ...clients.streamer import MemsinkStreamerClient
-
-from .. import init
-
-from .audio import AudioSource
-
-from .mic import MicSink
-
-from .server import MediaServer
+"use strict";
 
 
-# =====
-def main() -> None:
-    config = init(
-        prog="kvmd-media",
-        description="The media proxy",
-        check_run=True,
-    ).config.media
+// The mono capturer for the direct stream mode. It collects the audio
+// samples to the frames of the required size and sends them to the main
+// thread as Float32Array.
+class MicProcessor extends AudioWorkletProcessor {
+	constructor(options) {
+		super();
+		this.__size = options.processorOptions.size;
+		this.__buf = new Float32Array(this.__size);
+		this.__used = 0;
+	}
 
-    def make_streamer(name: str, fmt: int) -> (MemsinkStreamerClient | None):
-        if getattr(config.memsink, name).sink:
-            return MemsinkStreamerClient(fmt, **getattr(config.memsink, name)._unpack())
-        return None
+	process(inputs) {
+		let chunk = ((inputs.length > 0 && inputs[0].length > 0) ? inputs[0][0] : null);
+		if (chunk) {
+			for (let index = 0; index < chunk.length; ++index) {
+				this.__buf[this.__used] = chunk[index];
+				this.__used += 1;
+				if (this.__used >= this.__size) {
+					let frame = this.__buf.slice(0);
+					this.port.postMessage(frame, [frame.buffer]);
+					this.__used = 0;
+				}
+			}
+		}
+		return true;
+	}
+}
 
-    MediaServer(
-        h264_streamer=make_streamer("h264", StreamerFormats.H264),
-        jpeg_streamer=make_streamer("jpeg", StreamerFormats.JPEG),
-        audio=AudioSource(**config.audio._unpack()),
-        mic=MicSink(**config.mic._unpack()),
-    ).run(**config.server._unpack())
+registerProcessor("kvmd-mic", MicProcessor);

--- a/web/share/js/kvm/stream.js
+++ b/web/share/js/kvm/stream.js
@@ -84,6 +84,7 @@ export function Streamer() {
 			let enabled = $("stream-multimedia-switch").checked;
 			tools.el.setEnabled($("stream-audio-volume-slider"), enabled);
 			tools.el.setEnabled($("stream-mic-switch"), enabled);
+			tools.el.setEnabled($("stream-mic-raw-switch"), enabled);
 			tools.el.setEnabled($("stream-camera-switch"), enabled);
 			__applyAudioVolume();
 			__applyMicEnabled();
@@ -92,6 +93,8 @@ export function Streamer() {
 		}, false);
 
 		tools.storage.bindSimpleSlider($("stream-audio-volume-slider"), "stream.audio", 0, 100, 1, 100, __applyAudioVolume);
+
+		tools.storage.bindSimpleSwitch($("stream-mic-raw-switch"), "stream.mic.raw", false, __applyMicEnabled);
 
 		for (let [input, apply_cb] of [["mic", __applyMicEnabled], ["camera", __applyCameraEnabled]]) {
 			tools.storage.bindSimpleSwitch($(`stream-${input}-switch`), `stream.${input}`, false, apply_cb);
@@ -133,6 +136,7 @@ export function Streamer() {
 		let enabled = ($("stream-multimedia-switch").checked && $("stream-mic-switch").checked);
 		let el = $("stream-mic-selector");
 		tools.el.setEnabled(el, enabled);
+		__streamer.setMicRaw($("stream-mic-raw-switch").checked);
 		__streamer.setMicDevice(enabled ? el.value : null);
 	};
 

--- a/web/share/js/kvm/stream_janus.js
+++ b/web/share/js/kvm/stream_janus.js
@@ -24,6 +24,7 @@
 
 
 import {tools, $} from "../tools.js";
+import {MicLevel} from "./mic_level.js";
 import {wm} from "../wm.js";
 
 
@@ -53,6 +54,8 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 
 	var __has_mic = false;
 	var __use_mic = null;
+	var __use_mic_raw = false;
+	var __mic_level = new MicLevel();
 
 	var __has_camera = false;
 	var __use_camera = null;
@@ -70,6 +73,8 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 		tools.feature.setEnabled($("stream-multimedia"), false);
 		tools.feature.setEnabled($("stream-audio"), false);
 		tools.feature.setEnabled($("stream-mic"), false);
+		tools.feature.setEnabled($("stream-mic-raw"), false);
+		tools.feature.setEnabled($("stream-mic-level"), false);
 		tools.feature.setEnabled($("stream-camera"), false);
 	};
 
@@ -135,6 +140,15 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 				}
 			}
 		}, {[av]: true});
+	};
+
+	self.setMicRaw = function(raw) {
+		if (__use_mic_raw !== !!raw) {
+			__use_mic_raw = !!raw;
+			if (__has_mic && __use_mic) {
+				__destroyJanus(); // The constraints are negotiated with the offer
+			}
+		}
 	};
 
 	self.setMicDevice = function(mic, reload=false) {
@@ -308,6 +322,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	};
 
 	var __destroyJanus = function() {
+		__mic_level.detach();
 		if (__janus !== null) {
 			__janus.destroy();
 		}
@@ -403,6 +418,8 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 						let f = msg.result.features;
 						tools.feature.setEnabled($("stream-audio"), (__has_audio = f.audio));
 						tools.feature.setEnabled($("stream-mic"), (__has_mic = f.mic));
+						tools.feature.setEnabled($("stream-mic-raw"), __has_mic);
+						tools.feature.setEnabled($("stream-mic-level"), __has_mic);
 						tools.feature.setEnabled($("stream-camera"), (__has_camera = (f.camera && f.camera.enabled)));
 						tools.feature.setEnabled($("stream-multimedia"), (__has_audio || __has_mic || __has_camera));
 						__ice = f.ice;
@@ -444,7 +461,15 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 
 					let mic = null;
 					if (__has_mic && __use_mic) {
-						mic = (__use_mic === ".__default__" ? true : {"deviceId": {"exact": __use_mic}});
+						mic = (__use_mic === ".__default__" ? {} : {"deviceId": {"exact": __use_mic}});
+						if (__use_mic_raw) {
+							// The echo cancellation stays on: without it the host would hear
+							// its own sound back through the microphone
+							mic["noiseSuppression"] = false;
+							mic["autoGainControl"] = false;
+						} else if (Object.keys(mic).length === 0) {
+							mic = true; // The plain default capture
+						}
 					}
 
 					let camera = null;
@@ -527,6 +552,14 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 			},
 
 			"onlocaltrack": function(track, added) {
+				if (track.kind === "audio") {
+					// The microphone is captured by Janus, so the meter just listens to it
+					if (added) {
+						__mic_level.attach(track);
+					} else {
+						__mic_level.detach();
+					}
+				}
 				// https://bugzilla.mozilla.org/show_bug.cgi?id=1831521
 				if (added && track.kind === "video") {
 					if ("contentHint" in track) { // WebKit

--- a/web/share/js/kvm/stream_janus.js
+++ b/web/share/js/kvm/stream_janus.js
@@ -55,6 +55,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	var __has_mic = false;
 	var __use_mic = null;
 	var __use_mic_raw = false;
+	var __mic_pending = null;
 	var __mic_level = new MicLevel();
 
 	var __has_camera = false;
@@ -152,7 +153,14 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	};
 
 	self.setMicDevice = function(mic, reload=false) {
-		if (__has_mic && (__use_mic !== mic)) {
+		if (!__has_mic) {
+			// The features are not known yet: this happens right after switching the video
+			// mode, when the UI applies its state to the fresh streamer. Remember the latest
+			// choice, including a withdrawal, and replay it when the features arrive.
+			__mic_pending = mic;
+			return;
+		}
+		if (__use_mic !== mic) {
 			if (mic) {
 				__refillDevices("mic", mic, function(id) {
 					__use_mic = id;
@@ -420,6 +428,13 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 						tools.feature.setEnabled($("stream-mic"), (__has_mic = f.mic));
 						tools.feature.setEnabled($("stream-mic-raw"), __has_mic);
 						tools.feature.setEnabled($("stream-mic-level"), __has_mic);
+						if (__mic_pending !== null) { // The UI asked before we knew the features
+							let mic = __mic_pending;
+							__mic_pending = null;
+							if (__has_mic) {
+								self.setMicDevice(mic);
+							}
+						}
 						tools.feature.setEnabled($("stream-camera"), (__has_camera = (f.camera && f.camera.enabled)));
 						tools.feature.setEnabled($("stream-multimedia"), (__has_audio || __has_mic || __has_camera));
 						__ice = f.ice;

--- a/web/share/js/kvm/stream_media.js
+++ b/web/share/js/kvm/stream_media.js
@@ -24,6 +24,8 @@
 
 
 import {tools, $} from "../tools.js";
+import {wm} from "../wm.js";
+import {MicLevel} from "./mic_level.js";
 
 
 export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook, __organizeHook) {
@@ -46,8 +48,27 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 
 	var __state = null;
 	var __fps_accum = 0;
+	var __bytes_accum = 0;
 
 	var __orient = 0;
+
+	var __audio_info = null; // Audio params from the server
+	var __audio_volume = 0; // Requested volume
+	var __audio = null; // Active player
+	var __audio_starting = false;
+	var __audio_failed = false; // Don't retry the broken audio in a loop
+	var __audio_error = ""; // The last error reported by the server
+	var __audio_grace_timer = null;
+
+	var __mic_level = new MicLevel();
+
+	var __mic_info = null; // Mic params from the server
+	var __mic_req = null; // Requested mic device ID
+	var __mic_raw = false; // Requested capture without the browser's noise processing
+	var __mic = null; // Active capturer
+	var __mic_starting = false;
+	var __mic_failed = false; // Don't retry the broken mic in a loop
+	var __mic_retries = 0;
 
 	var __init__ = function() {
 		tools.feature.setEnabled($("stream-orient"), true);
@@ -62,12 +83,46 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	/************************************************************************/
 
 	self.setOrientation = function(orient) { __orient = orient; };
-	self.setAudioVolume = function(volume) {}; // eslint-disable-line no-unused-vars
-	self.setMicDevice = function(mic) {}; // eslint-disable-line no-unused-vars
-	self.setMicRaw = function(raw) {}; // eslint-disable-line no-unused-vars
 	self.setCameraDevice = function(camera) {}; // eslint-disable-line no-unused-vars
 
-	self.getName = () => "Direct H.264";
+	self.setAudioVolume = function(volume) {
+		let prev = __audio_volume;
+		__audio_volume = volume;
+		if (!prev !== !volume) {
+			__audio_failed = false; // The user has changed their mind
+		}
+		if (__audio !== null) {
+			__audio.gain.gain.value = volume / 100;
+		}
+		__ensureAudio();
+	};
+
+	self.setMicDevice = function(mic) {
+		if (__mic_req !== mic) {
+			__mic_req = mic;
+			__mic_failed = false;
+			__ensureMic();
+		}
+	};
+
+	self.setMicRaw = function(raw) {
+		if (__mic_raw !== !!raw) {
+			__mic_raw = !!raw;
+			__mic_failed = false;
+			__ensureMic();
+		}
+	};
+
+	self.getName = function() {
+		let extra = [];
+		if (__audio !== null) {
+			extra.push("Audio");
+		}
+		if (__mic !== null) {
+			extra.push("Mic");
+		}
+		return ["Direct H.264", ...extra].join(" + ");
+	};
 	self.getMode = () => "media";
 
 	self.getResolution = function() {
@@ -91,6 +146,531 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 		__ensuring = false;
 		__wsForceClose();
 		__setInfo(false, false, "");
+	};
+
+	var __updateMultimedia = function() {
+		tools.feature.setEnabled($("stream-multimedia"), (__audio_info !== null || __mic_info !== null));
+	};
+
+	var __isWsReady = () => (__ws !== null && __ws.readyState === WebSocket.OPEN);
+
+	/************************************************************************/
+	/*                                 AUDIO                                */
+	/************************************************************************/
+
+	var __AUDIO_LAG = 0.06; // Buffer 60ms of the audio to smooth the network jitter
+	var __AUDIO_MIN_LAG = 0.01; // Below this we have nothing to play: resync
+	var __AUDIO_MAX_LAG = __AUDIO_LAG + 0.1; // Above this the lag is just a delay: catch up
+	var __AUDIO_FADE = 0.005; // Ramp the first frame after a discontinuity to avoid a click
+	var __AUDIO_GRACE = 15000; // The server retries the capture, so don't alarm the user at once
+
+	var __MIC_RETRIES = 5; // The playback device can be busy for a while after a mode switch
+	var __MIC_RETRY_DELAY = 3000;
+
+	var __setupAudio = function(info) {
+		__audio_info = ((info && window.AudioContext) ? info : null);
+		__audio_failed = false; // The new session deserves the new try
+		tools.feature.setEnabled($("stream-audio"), (__audio_info !== null));
+		__updateMultimedia();
+		__ensureAudio();
+	};
+
+	var __ensureAudio = function() {
+		if (__audio_volume > 0 && !__audio_failed && __audio_info !== null && !__stop && __isWsReady()) {
+			if (__audio === null && !__audio_starting) {
+				__audio_starting = true;
+				__startAudio().catch(function(err) {
+					__logInfo("Can't start the audio:", err);
+					__failAudio("Can't play the audio.<br>Check the browser permissions for it.", err);
+				}).finally(function() {
+					__audio_starting = false;
+					__ensureAudio(); // Something might have changed while we were starting
+				});
+			}
+		} else {
+			__stopAudio(true);
+		}
+	};
+
+	var __startAudio = async () => {
+		let audio = {
+			"ctx": null, "gain": null, "decoder": null, "format": "pcm",
+			"ts": 0, "time": 0, "faded": false, "resyncs": 0, "drops": 0,
+		};
+		try {
+			audio.format = await __chooseAudioFormat();
+
+			audio.ctx = new AudioContext({"sampleRate": __audio_info.hz, "latencyHint": "interactive"});
+			audio.gain = audio.ctx.createGain();
+			audio.gain.gain.value = __audio_volume / 100;
+			audio.gain.connect(audio.ctx.destination);
+
+			if (audio.format === "opus") {
+				audio.decoder = new AudioDecoder({
+					"output": (frame) => __playAudioFrame(audio, frame),
+					"error": (err) => __logInfo("Audio decoder error:", err),
+				});
+				audio.decoder.configure(__makeAudioDecoderConfig());
+			}
+
+			if (audio.ctx.state === "suspended") {
+				await audio.ctx.resume();
+			}
+
+			if (__audio_volume <= 0 || !__isWsReady()) { // Something has changed while we were starting
+				__closeAudio(audio);
+				__logInfo("Audio start cancelled");
+				return;
+			}
+			__ws.send(JSON.stringify({
+				"event_type": "audio_start",
+				"event": {"format": audio.format},
+			}));
+			__audio = audio;
+			__logInfo(`Audio started (${audio.format})`);
+		} catch (err) {
+			__closeAudio(audio);
+			throw err;
+		}
+	};
+
+	var __makeAudioDecoderConfig = function() {
+		return {
+			"codec": "opus",
+			"sampleRate": __audio_info.hz,
+			"numberOfChannels": __audio_info.channels,
+		};
+	};
+
+	var __chooseAudioFormat = async () => {
+		if (__audio_info.formats.includes("opus") && window.AudioDecoder) {
+			try {
+				let sup = await AudioDecoder.isConfigSupported(__makeAudioDecoderConfig());
+				if (sup.supported) {
+					return "opus";
+				}
+			} catch (err) {
+				__logInfo("Can't check the Opus decoder:", err);
+			}
+		}
+		if (!__audio_info.formats.includes("pcm")) {
+			throw new Error("This browser can't decode the audio");
+		}
+		return "pcm";
+	};
+
+	var __recvAudioData = function(gap, raw) {
+		let audio = __audio;
+		if (audio === null) {
+			return;
+		}
+		if (__audio_grace_timer !== null) {
+			__clearAudioGrace(); // The server has recovered the capture
+		}
+		if (gap) {
+			// The server dropped something: the sound will jump, so ramp it in
+			audio.faded = false;
+		}
+		if (audio.decoder === null) {
+			__playAudioPcm(audio, raw);
+		} else if (audio.decoder.state === "configured") {
+			audio.decoder.decode(new EncodedAudioChunk({
+				"type": "key", // Opus frames are always the key frames
+				"timestamp": audio.ts,
+				"data": raw,
+			}));
+			audio.ts += __audio_info.frame_ms * 1000;
+		}
+	};
+
+	var __playAudioFrame = function(audio, frame) {
+		try {
+			if (__audio !== audio) {
+				return;
+			}
+			let buf = audio.ctx.createBuffer(frame.numberOfChannels, frame.numberOfFrames, frame.sampleRate);
+			for (let ch = 0; ch < frame.numberOfChannels; ++ch) {
+				frame.copyTo(buf.getChannelData(ch), {"planeIndex": ch, "format": "f32-planar"});
+			}
+			__playAudioBuffer(audio, buf);
+		} catch (err) {
+			__logInfo("Can't play the audio frame:", err);
+		} finally {
+			frame.close();
+		}
+	};
+
+	var __playAudioPcm = function(audio, raw) {
+		let channels = __audio_info.channels;
+		let pcm = new Int16Array(raw);
+		let count = Math.floor(pcm.length / channels);
+		if (count === 0) {
+			return;
+		}
+		let buf = audio.ctx.createBuffer(channels, count, __audio_info.hz);
+		for (let ch = 0; ch < channels; ++ch) {
+			let plane = buf.getChannelData(ch);
+			for (let index = 0; index < count; ++index) {
+				plane[index] = pcm[index * channels + ch] / 32768;
+			}
+		}
+		__playAudioBuffer(audio, buf);
+	};
+
+	var __playAudioBuffer = function(audio, buf) {
+		let now = audio.ctx.currentTime;
+		if (audio.time < now + __AUDIO_MIN_LAG) {
+			// The first frame or we have fallen behind: resync the playback
+			audio.time = now + __AUDIO_LAG;
+			audio.resyncs += 1;
+			audio.faded = false;
+		} else if (audio.time > now + __AUDIO_MAX_LAG) {
+			// The lag has grown (a burst after a stall), drop the frame to catch up
+			audio.drops += 1;
+			audio.faded = false;
+			return;
+		}
+		if (!audio.faded) {
+			__fadeInAudio(buf); // Don't splice the sound at a random amplitude
+			audio.faded = true;
+		}
+		let src = audio.ctx.createBufferSource();
+		src.buffer = buf;
+		src.connect(audio.gain);
+		src.start(audio.time);
+		audio.time += buf.duration;
+	};
+
+	var __fadeInAudio = function(buf) {
+		let count = Math.min(Math.round(__AUDIO_FADE * buf.sampleRate), buf.length);
+		for (let ch = 0; ch < buf.numberOfChannels; ++ch) {
+			let plane = buf.getChannelData(ch);
+			for (let index = 0; index < count; ++index) {
+				plane[index] *= (1 - Math.cos(Math.PI * index / count)) / 2;
+			}
+		}
+	};
+
+	var __clearAudioGrace = function() {
+		if (__audio_grace_timer !== null) {
+			clearTimeout(__audio_grace_timer);
+			__audio_grace_timer = null;
+		}
+		__audio_error = "";
+	};
+
+	var __failAudioLate = function() {
+		// The server hasn't recovered the capture in time, now it's a real error
+		__audio_grace_timer = null;
+		__failAudio("The audio is not available on PiKVM.", __audio_error);
+	};
+
+	var __failAudio = function(html, err) {
+		__audio_failed = true;
+		__stopAudio(true);
+		if (__audio_volume > 0) { // Not a cancellation by the user
+			wm.error(html, err);
+		}
+	};
+
+	var __stopAudio = function(notify) {
+		__clearAudioGrace();
+		let audio = __audio;
+		__audio = null;
+		if (audio !== null) {
+			__closeAudio(audio);
+			if (notify && __isWsReady()) {
+				try {
+					__ws.send(JSON.stringify({"event_type": "audio_stop", "event": {}}));
+				} catch {}
+			}
+			__logInfo(`Audio stopped (resyncs=${audio.resyncs}, drops=${audio.drops})`);
+		}
+	};
+
+	var __closeAudio = function(audio) {
+		for (let close of [
+			() => { if (audio.decoder !== null && audio.decoder.state !== "closed") { audio.decoder.close(); } },
+			() => { if (audio.gain !== null) { audio.gain.disconnect(); } },
+			() => { if (audio.ctx !== null) { audio.ctx.close(); } },
+		]) {
+			try {
+				close();
+			} catch (err) {
+				__logInfo("Can't close the audio:", err);
+			}
+		}
+	};
+
+	/************************************************************************/
+	/*                              MICROPHONE                              */
+	/************************************************************************/
+
+	var __setupMic = function(info) {
+		// The worklet-based capturer is mono-only, as well as the server side
+		let sup = (window.AudioWorkletNode && navigator.mediaDevices);
+		__mic_info = ((info && info.channels === 1 && sup) ? info : null);
+		__mic_failed = false; // The new session deserves the new try
+		tools.feature.setEnabled($("stream-mic"), (__mic_info !== null));
+		tools.feature.setEnabled($("stream-mic-raw"), (__mic_info !== null));
+		tools.feature.setEnabled($("stream-mic-level"), (__mic_info !== null));
+		__updateMultimedia();
+		__ensureMic();
+	};
+
+	var __ensureMic = function() {
+		if (__mic_req && !__mic_failed && __mic_info !== null && !__stop && __isWsReady()) {
+			if (__mic !== null && (__mic.id !== __mic_req || __mic.raw !== __mic_raw)) {
+				__stopMic(true); // The device or the capture mode was changed by the user
+			}
+			if (__mic === null && !__mic_starting) {
+				__mic_starting = true;
+				__startMic().catch(function(err) {
+					__logInfo("Can't start the mic:", err);
+					__failMic("Can't start the microphone.<br>Check the browser permissions for it.", err);
+				}).finally(function() {
+					__mic_starting = false;
+					__ensureMic(); // Something might have changed while we were starting
+				});
+			}
+		} else {
+			__stopMic(true);
+		}
+	};
+
+	var __startMic = async () => {
+		let mic = {
+			"id": __mic_req, "raw": __mic_raw, "stream": null, "ctx": null, "src": null,
+			"node": null, "encoder": null, "format": "pcm", "ts": 0,
+		};
+		try {
+			let want = __mic_req; // The request we've started for
+			let id = want;
+			try {
+				mic.stream = await __getMicStream(id, mic.raw);
+			} catch (err) {
+				if (id === ".__default__") {
+					throw err;
+				}
+				// The stored device is gone, so we're falling back to the default one
+				__logInfo("Can't use the selected mic device:", err);
+				id = ".__default__";
+				if (__mic_req === want) { // The user might have turned the mic off meanwhile
+					__mic_req = id;
+				}
+				mic.id = id;
+				mic.stream = await __getMicStream(id, mic.raw);
+			}
+			mic.format = await __chooseMicFormat();
+			if (mic.format === "opus") {
+				mic.encoder = new AudioEncoder({
+					"output": (chunk) => __sendMicChunk(mic, chunk),
+					"error": (err) => __logInfo("Mic encoder error:", err),
+				});
+				mic.encoder.configure(__makeMicEncoderConfig());
+			}
+
+			mic.ctx = new AudioContext({"sampleRate": __mic_info.hz});
+			await mic.ctx.audioWorklet.addModule(new URL("mic_worklet.js", import.meta.url));
+			mic.node = new AudioWorkletNode(mic.ctx, "kvmd-mic", {
+				"numberOfInputs": 1,
+				"numberOfOutputs": 0,
+				"channelCount": 1,
+				"channelCountMode": "explicit",
+				"processorOptions": {"size": Math.round(__mic_info.hz * __mic_info.frame_ms / 1000)},
+			});
+			mic.node.port.onmessage = (ev) => __sendMicFrame(mic, ev.data);
+			// The source must be kept referenced: the graph is not connected
+			// to the context destination, so it can be garbage collected
+			mic.src = mic.ctx.createMediaStreamSource(mic.stream);
+			mic.src.connect(mic.node);
+			if (mic.ctx.state === "suspended") {
+				await mic.ctx.resume();
+			}
+
+			if (__mic_req !== mic.id || !__isWsReady()) { // Something has changed meanwhile
+				__closeMic(mic);
+				__logInfo("Mic start cancelled");
+				return;
+			}
+			await __refillMicDevices(id); // Only now it's our device for sure
+			__ws.send(JSON.stringify({
+				"event_type": "mic_start",
+				"event": {"format": mic.format},
+			}));
+			__mic = mic;
+			__logInfo(`Mic started (${mic.format})`);
+		} catch (err) {
+			__closeMic(mic);
+			throw err;
+		}
+	};
+
+	var __getMicStream = function(id, raw) {
+		let audio = (id === ".__default__" ? {} : {"deviceId": {"exact": id}});
+		if (raw) {
+			// The echo cancellation stays on: the host audio is played by the same page,
+			// so without it the host would hear itself back through the microphone
+			audio["noiseSuppression"] = false;
+			audio["autoGainControl"] = false;
+		}
+		return navigator.mediaDevices.getUserMedia({"audio": audio});
+	};
+
+	var __refillMicDevices = async (id) => {
+		// The device labels are available only after the permission is granted
+		let el = $("stream-mic-selector");
+		let devices = await navigator.mediaDevices.enumerateDevices();
+		el.options.length = 1;
+		let found = false;
+		for (let dev of devices) {
+			if (dev.kind === "audioinput") {
+				tools.selector.addOption(el, dev.label, dev.deviceId);
+				if (dev.deviceId === id) {
+					found = true;
+				}
+			}
+		}
+		el.value = (found ? id : ".__default__");
+		tools.storage.set("stream.mic.device.id", el.value);
+		let name = "\u2500 Unknown yet \u2500";
+		try {
+			name = el.options[el.selectedIndex].innerText;
+		} catch {}
+		tools.storage.set("stream.mic.device.name", name);
+	};
+
+	var __makeMicEncoderConfig = function() {
+		return {
+			"codec": "opus",
+			"sampleRate": __mic_info.hz,
+			"numberOfChannels": __mic_info.channels,
+			"bitrate": 48000,
+			"opus": {"frameDuration": __mic_info.frame_ms * 1000},
+		};
+	};
+
+	var __chooseMicFormat = async () => {
+		if (__mic_info.formats.includes("opus") && window.AudioEncoder) {
+			try {
+				let sup = await AudioEncoder.isConfigSupported(__makeMicEncoderConfig());
+				if (sup.supported) {
+					return "opus";
+				}
+			} catch (err) {
+				__logInfo("Can't check the Opus encoder:", err);
+			}
+		}
+		if (!__mic_info.formats.includes("pcm")) {
+			throw new Error("This browser can't encode the mic audio");
+		}
+		return "pcm";
+	};
+
+	var __sendMicFrame = function(mic, samples) {
+		if (__mic !== mic) {
+			return;
+		}
+		__mic_level.feed(samples);
+		if (mic.encoder === null) {
+			__sendMicData(mic, __makeMicPcm(samples));
+		} else if (mic.encoder.state === "configured") {
+			let data = new AudioData({
+				"format": "f32-planar",
+				"sampleRate": __mic_info.hz,
+				"numberOfFrames": samples.length,
+				"numberOfChannels": 1,
+				"timestamp": mic.ts,
+				"data": samples,
+			});
+			mic.ts += Math.round(samples.length * 1000000 / __mic_info.hz);
+			try {
+				mic.encoder.encode(data);
+			} finally {
+				data.close();
+			}
+		}
+	};
+
+	var __sendMicChunk = function(mic, chunk) {
+		let data = new Uint8Array(chunk.byteLength);
+		chunk.copyTo(data);
+		__sendMicData(mic, data);
+	};
+
+	var __makeMicPcm = function(samples) {
+		let pcm = new Int16Array(samples.length);
+		for (let index = 0; index < samples.length; ++index) {
+			let value = Math.max(-1, Math.min(1, samples[index]));
+			pcm[index] = Math.round(value * 32767);
+		}
+		return new Uint8Array(pcm.buffer);
+	};
+
+	var __MIC_MAX_BUFFERED = 262144; // Drop the mic frames if the uplink can't keep up
+
+	var __sendMicData = function(mic, data) {
+		if (__mic !== mic || !__isWsReady() || __ws.bufferedAmount > __MIC_MAX_BUFFERED) {
+			return;
+		}
+		let msg = new Uint8Array(data.length + 1);
+		msg[0] = 2; // Mic frame
+		msg.set(data, 1);
+		try {
+			__ws.send(msg);
+		} catch (err) {
+			__logInfo("Can't send the mic frame:", err);
+		}
+	};
+
+	var __retryMic = function() {
+		if (__mic !== null && __mic_req && __isWsReady()) {
+			__logInfo(`Retrying the mic (${__mic_retries}/${__MIC_RETRIES}) ...`);
+			__ws.send(JSON.stringify({
+				"event_type": "mic_start",
+				"event": {"format": __mic.format},
+			}));
+		}
+	};
+
+	var __failMic = function(html, err) {
+		__mic_failed = true;
+		__stopMic(true);
+		if (__mic_req) { // Not a cancellation by the user
+			wm.error(html, err);
+		}
+	};
+
+	var __stopMic = function(notify) {
+		__mic_retries = 0;
+		let mic = __mic;
+		__mic = null;
+		if (mic !== null) {
+			__closeMic(mic);
+			if (notify && __isWsReady()) {
+				try {
+					__ws.send(JSON.stringify({"event_type": "mic_stop", "event": {}}));
+				} catch {}
+			}
+			__mic_level.reset();
+			__logInfo("Mic stopped");
+		}
+	};
+
+	var __closeMic = function(mic) {
+		for (let close of [
+			() => { if (mic.src !== null) { mic.src.disconnect(); } },
+			() => { if (mic.node !== null) { mic.node.port.onmessage = null; mic.node.disconnect(); } },
+			() => { if (mic.encoder !== null && mic.encoder.state !== "closed") { mic.encoder.close(); } },
+			() => { if (mic.ctx !== null) { mic.ctx.close(); } },
+			() => { if (mic.stream !== null) { mic.stream.getTracks().forEach((track) => track.stop()); } },
+		]) {
+			try {
+				close();
+			} catch (err) {
+				__logInfo("Can't close the mic:", err);
+			}
+		}
 	};
 
 	var __ensureMedia = function(internal) {
@@ -135,10 +715,12 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 
 			if (__decoder && __decoder.state === "configured") {
 				let online = !!(__state && __state.source.online);
-				let info = `${__fps_accum} dyn.fps`;
-				__fps_accum = 0;
-				__setInfo(true, online, info);
+				// Everything the socket delivers: the video and the host audio
+				let kbps = Math.round(__bytes_accum * 8 / 1000);
+				__setInfo(true, online, `${kbps} kbps / ${__fps_accum} dyn.fps`);
 			}
+			__fps_accum = 0;
+			__bytes_accum = 0;
 		} catch (ex) {
 			__wsErrorHandler(ex.message);
 		}
@@ -161,6 +743,8 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 
 	var __wsCloseHandler = function(ev) {
 		__logInfo("Socket closed:", ev);
+		__stopAudio(false);
+		__stopMic(false);
 		if (__ping_timer) {
 			clearInterval(__ping_timer);
 			__ping_timer = null;
@@ -168,6 +752,7 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 		__closeDecoder();
 		__missed_heartbeats = 0;
 		__fps_accum = 0;
+		__bytes_accum = 0;
 		__ws = null;
 		if (!__stop) {
 			setTimeout(() => __ensureMedia(true), 1000);
@@ -177,6 +762,46 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	var __wsJsonHandler = function(ev_type, ev) {
 		if (ev_type === "media") {
 			__setupCodec(ev.video);
+			__setupAudio(ev.audio);
+			__setupMic(ev.mic);
+			if (__audio_info !== null || __mic_info !== null) {
+				// Ask the user if the multimedia settings of the previous session
+				// should be restored: the browser needs a gesture to play the audio
+				__watchHook();
+			}
+		} else if (ev_type === "audio_state") {
+			if (ev.error) {
+				__logInfo("Audio error on the server:", ev.error);
+				__audio_error = ev.error;
+				if (__audio !== null && __audio_grace_timer === null) {
+					// The capture device is busy for a while after switching from WebRTC,
+					// and the server retries it, so we just wait for the frames to arrive
+					__audio_grace_timer = setTimeout(__failAudioLate, __AUDIO_GRACE);
+				} else if (__audio === null && !__audio_starting) {
+					// While we're starting, the error belongs to the previous session
+					__failAudio("The audio is not available on PiKVM.", ev.error);
+				}
+			} else if (ev.started) {
+				__clearAudioGrace();
+			}
+		} else if (ev_type === "mic_state") {
+			if (ev.error) {
+				__logInfo("Mic error on the server:", ev.error);
+				if (__mic !== null && __mic_req && __mic_retries < __MIC_RETRIES) {
+					// The playback device is busy for a while after switching from WebRTC
+					__mic_retries += 1;
+					setTimeout(__retryMic, __MIC_RETRY_DELAY);
+				} else if (__mic !== null || !__mic_starting) {
+					// While we're starting, the error belongs to the previous session
+					__mic_failed = true;
+					__stopMic(false);
+					if (__mic_req) { // Not a cancellation by the user
+						wm.error("The microphone is not available on PiKVM.", ev.error);
+					}
+				}
+			} else if (ev.started) {
+				__mic_retries = 0;
+			}
 		}
 	};
 
@@ -205,6 +830,7 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	};
 
 	var __wsBinHandler = async (data) => {
+		__bytes_accum += data.byteLength;
 		let header = new Uint8Array(data.slice(0, 2));
 		if (header[0] === 255) { // Pong
 			__missed_heartbeats = 0;
@@ -212,6 +838,12 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 			let key = !!header[1];
 			if (await __ensureDecoder(key)) {
 				await __processFrame(key, data.slice(2));
+			}
+		} else if (header[0] === 3) { // Audio frame
+			try {
+				__recvAudioData(!!(header[1] & 1), data.slice(2));
+			} catch (err) { // The video must survive the broken audio
+				__logInfo("Can't play the audio frame:", err);
 			}
 		}
 	};

--- a/web/share/js/kvm/stream_media.js
+++ b/web/share/js/kvm/stream_media.js
@@ -54,6 +54,8 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 		tools.feature.setEnabled($("stream-multimedia"), false);
 		tools.feature.setEnabled($("stream-audio"), false);
 		tools.feature.setEnabled($("stream-mic"), false);
+		tools.feature.setEnabled($("stream-mic-raw"), false);
+		tools.feature.setEnabled($("stream-mic-level"), false);
 		tools.feature.setEnabled($("stream-camera"), false);
 	};
 
@@ -62,6 +64,7 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	self.setOrientation = function(orient) { __orient = orient; };
 	self.setAudioVolume = function(volume) {}; // eslint-disable-line no-unused-vars
 	self.setMicDevice = function(mic) {}; // eslint-disable-line no-unused-vars
+	self.setMicRaw = function(raw) {}; // eslint-disable-line no-unused-vars
 	self.setCameraDevice = function(camera) {}; // eslint-disable-line no-unused-vars
 
 	self.getName = () => "Direct H.264";

--- a/web/share/js/kvm/stream_mjpeg.js
+++ b/web/share/js/kvm/stream_mjpeg.js
@@ -45,6 +45,8 @@ export function MjpegStreamer(__setActive, __setInactive, __setInfo, __watchHook
 		tools.feature.setEnabled($("stream-multimedia"), false);
 		tools.feature.setEnabled($("stream-audio"), false);
 		tools.feature.setEnabled($("stream-mic"), false);
+		tools.feature.setEnabled($("stream-mic-raw"), false);
+		tools.feature.setEnabled($("stream-mic-level"), false);
 		tools.feature.setEnabled($("stream-camera"), false);
 	};
 
@@ -53,6 +55,7 @@ export function MjpegStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	self.setOrientation = function(orient) {}; // eslint-disable-line no-unused-vars
 	self.setAudioVolume = function(volume) {}; // eslint-disable-line no-unused-vars
 	self.setMicDevice = function(mic) {}; // eslint-disable-line no-unused-vars
+	self.setMicRaw = function(raw) {}; // eslint-disable-line no-unused-vars
 	self.setCameraDevice = function(camera) {}; // eslint-disable-line no-unused-vars
 
 	self.getName = () => "HTTP MJPEG";


### PR DESCRIPTION
**On hold** pending the audio server discussion below — @mdevaev is right that the direct mode
shouldn't take the ALSA devices for itself, and I'd rather agree on the architecture before
rewriting anything.

Stacked on #241, which carries the level meter and the raw capture switch. Those work in the
`WebRTC` mode on their own and don't depend on any of this, so they're reviewable separately;
this PR shows their commits until #241 is merged.

What's left here is the direct-mode audio itself: KVMD-Media captures the HDMI audio from the
TC358743, resamples it when the host isn't at 48 kHz, encodes Opus and sends it over the
websocket that already carries the video; the microphone goes the other way and is played to
the USB gadget. libasound, libopus and libspeexdsp are bound with ctypes.

It works and it's tested on a V4 Mini, but as it stands both devices are opened directly, so
the direct mode and WebRTC can't have audio at the same time — with `kvmd-janus-static` running,
janus holds both devices permanently and the direct mode gets nothing at all. That's the part
that needs the intermediate audio server, and the capture/playback layer here is expected to be
replaced by a memsink client once its shape is agreed.

Closes pikvm/pikvm#1487 when it lands.
