### PR TITLE
Web UI: the raw microphone capture mode

### DIFF
--- a/web/kvm/index.html
+++ b/web/kvm/index.html
@@ -424,6 +424,16 @@
                   <select class="small" id="stream-mic-selector" style="width: 90%;" disabled></select>
                 </td>
               </tr>
+              <tr class="feature-disabled" id="stream-mic-raw">
+                <td>Raw microphone:</td>
+                <td>
+                      <div class="switch-box">
+                        <input disabled type="checkbox" id="stream-mic-raw-switch">
+                        <label for="stream-mic-raw-switch"><span class="switch-inner"></span><span class="switch"></span></label>
+                      </div>
+                </td>
+                <td class="tip">No noise suppression and no auto gain</td>
+              </tr>
               <tr class="feature-disabled" id="stream-camera">
                 <td>Camera:</td>
                 <td>

--- a/web/kvm/navbar-system.pug
+++ b/web/kvm/navbar-system.pug
@@ -126,6 +126,10 @@ li.right#system-dropdown
 					td Microphone:
 					td #[+menu_switch("stream-mic-switch", false, false)]
 					td #[select.small#stream-mic-selector(style="width: 90%;" disabled)]
+				tr.feature-disabled#stream-mic-raw
+					td Raw microphone:
+					td #[+menu_switch("stream-mic-raw-switch", false, false)]
+					td.tip No noise suppression and no auto gain
 				tr.feature-disabled#stream-camera
 					td Camera:
 					td #[+menu_switch("stream-camera-switch", false, false)]

--- a/web/share/js/kvm/stream.js
+++ b/web/share/js/kvm/stream.js
@@ -84,6 +84,7 @@ export function Streamer() {
 			let enabled = $("stream-multimedia-switch").checked;
 			tools.el.setEnabled($("stream-audio-volume-slider"), enabled);
 			tools.el.setEnabled($("stream-mic-switch"), enabled);
+			tools.el.setEnabled($("stream-mic-raw-switch"), enabled);
 			tools.el.setEnabled($("stream-camera-switch"), enabled);
 			__applyAudioVolume();
 			__applyMicEnabled();
@@ -92,6 +93,8 @@ export function Streamer() {
 		}, false);
 
 		tools.storage.bindSimpleSlider($("stream-audio-volume-slider"), "stream.audio", 0, 100, 1, 100, __applyAudioVolume);
+
+		tools.storage.bindSimpleSwitch($("stream-mic-raw-switch"), "stream.mic.raw", false, __applyMicEnabled);
 
 		for (let [input, apply_cb] of [["mic", __applyMicEnabled], ["camera", __applyCameraEnabled]]) {
 			tools.storage.bindSimpleSwitch($(`stream-${input}-switch`), `stream.${input}`, false, apply_cb);
@@ -133,6 +136,7 @@ export function Streamer() {
 		let enabled = ($("stream-multimedia-switch").checked && $("stream-mic-switch").checked);
 		let el = $("stream-mic-selector");
 		tools.el.setEnabled(el, enabled);
+		__streamer.setMicRaw($("stream-mic-raw-switch").checked);
 		__streamer.setMicDevice(enabled ? el.value : null);
 	};
 

--- a/web/share/js/kvm/stream_janus.js
+++ b/web/share/js/kvm/stream_janus.js
@@ -53,6 +53,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 
 	var __has_mic = false;
 	var __use_mic = null;
+	var __use_mic_raw = false;
 
 	var __has_camera = false;
 	var __use_camera = null;
@@ -70,6 +71,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 		tools.feature.setEnabled($("stream-multimedia"), false);
 		tools.feature.setEnabled($("stream-audio"), false);
 		tools.feature.setEnabled($("stream-mic"), false);
+		tools.feature.setEnabled($("stream-mic-raw"), false);
 		tools.feature.setEnabled($("stream-camera"), false);
 	};
 
@@ -135,6 +137,15 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 				}
 			}
 		}, {[av]: true});
+	};
+
+	self.setMicRaw = function(raw) {
+		if (__use_mic_raw !== !!raw) {
+			__use_mic_raw = !!raw;
+			if (__has_mic && __use_mic) {
+				__destroyJanus(); // The constraints are negotiated with the offer
+			}
+		}
 	};
 
 	self.setMicDevice = function(mic, reload=false) {
@@ -403,6 +414,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 						let f = msg.result.features;
 						tools.feature.setEnabled($("stream-audio"), (__has_audio = f.audio));
 						tools.feature.setEnabled($("stream-mic"), (__has_mic = f.mic));
+						tools.feature.setEnabled($("stream-mic-raw"), __has_mic);
 						tools.feature.setEnabled($("stream-camera"), (__has_camera = (f.camera && f.camera.enabled)));
 						tools.feature.setEnabled($("stream-multimedia"), (__has_audio || __has_mic || __has_camera));
 						__ice = f.ice;
@@ -445,6 +457,16 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 					let mic = null;
 					if (__has_mic && __use_mic) {
 						mic = (__use_mic === ".__default__" ? true : {"deviceId": {"exact": __use_mic}});
+						if (__use_mic_raw) {
+							// The raw capture needs an object, `true` means the browser defaults.
+							// The echo cancellation stays on: without it the host would hear
+							// its own sound back through the microphone
+							if (mic === true) {
+								mic = {};
+							}
+							mic["noiseSuppression"] = false;
+							mic["autoGainControl"] = false;
+						}
 					}
 
 					let camera = null;

--- a/web/share/js/kvm/stream_media.js
+++ b/web/share/js/kvm/stream_media.js
@@ -54,6 +54,7 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 		tools.feature.setEnabled($("stream-multimedia"), false);
 		tools.feature.setEnabled($("stream-audio"), false);
 		tools.feature.setEnabled($("stream-mic"), false);
+		tools.feature.setEnabled($("stream-mic-raw"), false);
 		tools.feature.setEnabled($("stream-camera"), false);
 	};
 
@@ -62,6 +63,7 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	self.setOrientation = function(orient) { __orient = orient; };
 	self.setAudioVolume = function(volume) {}; // eslint-disable-line no-unused-vars
 	self.setMicDevice = function(mic) {}; // eslint-disable-line no-unused-vars
+	self.setMicRaw = function(raw) {}; // eslint-disable-line no-unused-vars
 	self.setCameraDevice = function(camera) {}; // eslint-disable-line no-unused-vars
 
 	self.getName = () => "Direct H.264";

--- a/web/share/js/kvm/stream_mjpeg.js
+++ b/web/share/js/kvm/stream_mjpeg.js
@@ -45,6 +45,7 @@ export function MjpegStreamer(__setActive, __setInactive, __setInfo, __watchHook
 		tools.feature.setEnabled($("stream-multimedia"), false);
 		tools.feature.setEnabled($("stream-audio"), false);
 		tools.feature.setEnabled($("stream-mic"), false);
+		tools.feature.setEnabled($("stream-mic-raw"), false);
 		tools.feature.setEnabled($("stream-camera"), false);
 	};
 
@@ -53,6 +54,7 @@ export function MjpegStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	self.setOrientation = function(orient) {}; // eslint-disable-line no-unused-vars
 	self.setAudioVolume = function(volume) {}; // eslint-disable-line no-unused-vars
 	self.setMicDevice = function(mic) {}; // eslint-disable-line no-unused-vars
+	self.setMicRaw = function(raw) {}; // eslint-disable-line no-unused-vars
 	self.setCameraDevice = function(camera) {}; // eslint-disable-line no-unused-vars
 
 	self.getName = () => "HTTP MJPEG";


### PR DESCRIPTION
Split as asked. This one is only the raw mic switch now: the `setMicDevice()` bugfix went to
#242, the level meter to #243.

The browser applies noise suppression and automatic gain control to the microphone by default.
That is right for a headset, but it wrecks a line-in or anything musical: the gain pumps and the
suppressor eats whatever does not look like speech. The switch turns both of them off.

The echo cancellation stays on in both modes. The host audio is played by the same page, so
without it the host would hear its own sound back through the microphone.

The constraints are negotiated with the offer, so flipping the switch while the microphone is
running restarts the session. The other two streamers get a no-op stub and keep the row hidden.