### PR TITLE
Web UI: don't lose the microphone when the video mode is switched

### DIFF
--- a/web/share/js/kvm/stream_janus.js
+++ b/web/share/js/kvm/stream_janus.js
@@ -138,18 +138,23 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	};
 
 	self.setMicDevice = function(mic, reload=false) {
-		if (__has_mic && (__use_mic !== mic)) {
+		// The choice is remembered even before the features are known: this happens
+		// right after switching the video mode, when the UI applies its state to the
+		// fresh streamer. Only the restart needs the working session
+		if (__use_mic !== mic) {
 			if (mic) {
 				__refillDevices("mic", mic, function(id) {
 					__use_mic = id;
-					__destroyJanus();
+					if (__has_mic) {
+						__destroyJanus();
+					}
 				});
 			} else {
 				__use_mic = null;
 			}
 			reload = true;
 		}
-		if (reload) {
+		if (reload && __has_mic) {
 			__destroyJanus();
 		}
 	};


### PR DESCRIPTION
Switching the video mode (or just loading the page with `WebRTC` saved as the mode) builds a
fresh `JanusStreamer` and then applies the saved UI state to it. At that moment the features
message has not arrived yet, so `__has_mic` is still `false` and `setMicDevice()` dropped the
request without a trace: the switch in the menu stays on, but the microphone is not sent until
you toggle it off and on by hand.

The fix remembers the last request and replays it once the features are known. The `WATCH` is
not sent at that point yet, so the device is applied in place and the session that has just
started is not restarted; only a device that disappeared in the meantime still needs a new
offer, which is the path that already existed.

The camera has the same shape of bug, but I left it alone: it needs a bit more thought because
`__camera_req` is filled from the features message itself.