### PR TITLE
Web UI: the microphone level meter

### DIFF
--- a/web/kvm/index.html
+++ b/web/kvm/index.html
@@ -434,6 +434,12 @@
                 </td>
                 <td class="tip">No noise suppression and no auto gain</td>
               </tr>
+              <tr class="feature-disabled" id="stream-mic-level">
+                <td>Mic level:</td>
+                <td class="slider" colspan="2">
+                  <div class="progress" id="stream-mic-level-progress"><span class="progress-value" id="stream-mic-level-value"></span></div>
+                </td>
+              </tr>
               <tr class="feature-disabled" id="stream-camera">
                 <td>Camera:</td>
                 <td>

--- a/web/kvm/navbar-system.pug
+++ b/web/kvm/navbar-system.pug
@@ -130,6 +130,11 @@ li.right#system-dropdown
 					td Raw microphone:
 					td #[+menu_switch("stream-mic-raw-switch", false, false)]
 					td.tip No noise suppression and no auto gain
+				tr.feature-disabled#stream-mic-level
+					td Mic level:
+					td.slider(colspan="2")
+						.progress#stream-mic-level-progress
+							span.progress-value#stream-mic-level-value
 				tr.feature-disabled#stream-camera
 					td Camera:
 					td #[+menu_switch("stream-camera-switch", false, false)]

--- a/web/share/js/kvm/mic_level.js
+++ b/web/share/js/kvm/mic_level.js
@@ -1,0 +1,182 @@
+/*****************************************************************************
+#                                                                            #
+#    KVMD - The main PiKVM daemon.                                           #
+#                                                                            #
+#    Copyright (C) 2018-2024  Maxim Devaev <mdevaev@gmail.com>               #
+#                                                                            #
+#    This program is free software: you can redistribute it and/or modify    #
+#    it under the terms of the GNU General Public License as published by    #
+#    the Free Software Foundation, either version 3 of the License, or       #
+#    (at your option) any later version.                                     #
+#                                                                            #
+#    This program is distributed in the hope that it will be useful,         #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of          #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           #
+#    GNU General Public License for more details.                            #
+#                                                                            #
+#    You should have received a copy of the GNU General Public License       #
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.  #
+#                                                                            #
+*****************************************************************************/
+
+
+
+"use strict";
+
+
+import {tools, $} from "../tools.js";
+
+
+// The microphone level meter. The mic itself belongs to Janus, so the meter
+// just listens to the track that is being sent to the host.
+export function MicLevel() {
+	var self = this;
+
+	/************************************************************************/
+
+	var __FLOOR = -60; // The bottom of the scale, dBFS
+	var __RELEASE = 2; // The meter falls this many dB per frame, 100dB/s
+	var __CLIP = 0.99; // Everything above is a clipped sample
+	var __CLIP_HOLD = 40; // ... and the warning stays for 0.8s
+	var __PERIOD = 20; // The meter is updated 50 times per second
+
+	var __sum = 0;
+	var __count = 0;
+	var __peak = 0;
+
+	var __level_db = __FLOOR;
+	var __clipped = 0;
+
+	var __ctx = null;
+	var __resuming = false;
+	var __src = null;
+	var __analyser = null;
+	var __buf = null;
+	var __timer = null;
+
+	/************************************************************************/
+
+	self.attach = function(track) {
+		self.detach();
+		try {
+			// The bar jumps between the updates by default, this blends the steps
+			// without making the meter lag behind the sound
+			$("stream-mic-level-progress").querySelector(".progress-value")
+				.style.transition = `width ${__PERIOD}ms linear`;
+			__ctx = new AudioContext();
+			// The source must be kept referenced, otherwise it can be garbage collected
+			__src = __ctx.createMediaStreamSource(new MediaStream([track]));
+			__analyser = __ctx.createAnalyser();
+			// 1024 samples is about 21ms at 48kHz: the same window the direct mode
+			// measures, so both modes react to the sound in the same way
+			__analyser.fftSize = 1024;
+			__buf = new Float32Array(__analyser.fftSize);
+			__src.connect(__analyser); // Not connected to the destination: nothing is played
+			__timer = setInterval(__poll, __PERIOD);
+			__poll();
+		} catch (err) {
+			tools.error("MicLevel: Can't attach to the track:", err);
+			self.detach();
+		}
+	};
+
+	self.detach = function() {
+		if (__timer !== null) {
+			clearInterval(__timer);
+			__timer = null;
+		}
+		for (let close of [
+			() => { if (__src !== null) { __src.disconnect(); } },
+			() => { if (__analyser !== null) { __analyser.disconnect(); } },
+			() => { if (__ctx !== null) { __ctx.close(); } },
+		]) {
+			try {
+				close();
+			} catch (err) {
+				tools.error("MicLevel: Can't detach from the track:", err);
+			}
+		}
+		__resuming = false;
+		__src = null;
+		__analyser = null;
+		__buf = null;
+		__ctx = null;
+		self.reset();
+	};
+
+	self.reset = function() {
+		__sum = 0;
+		__count = 0;
+		__peak = 0;
+		__level_db = __FLOOR;
+		__clipped = 0;
+		__draw();
+	};
+
+	/************************************************************************/
+
+	var __poll = function() {
+		if (__ctx === null) {
+			return;
+		}
+		if (__ctx.state !== "running") {
+			if (!__resuming) { // One pending resume is enough
+				__resuming = true;
+				__ctx.resume().catch(function(err) {
+					tools.error("MicLevel: Can't resume the context:", err);
+				}).finally(function() {
+					__resuming = false;
+				});
+			}
+			return;
+		}
+		__analyser.getFloatTimeDomainData(__buf);
+		__accumulate(__buf);
+		__update();
+	};
+
+	var __accumulate = function(samples) {
+		for (let index = 0; index < samples.length; ++index) {
+			let value = Math.abs(samples[index]);
+			__sum += value * value;
+			if (value > __peak) {
+				__peak = value;
+			}
+		}
+		__count += samples.length;
+	};
+
+	var __update = function() {
+		if (__count === 0) {
+			return;
+		}
+		let rms = Math.sqrt(__sum / __count);
+		let db = (rms > 0 ? 20 * Math.log10(rms) : __FLOOR);
+		// The level jumps up instantly and falls smoothly, like any audio meter
+		__level_db = Math.max(db, __level_db - __RELEASE);
+		if (__peak >= __CLIP) {
+			__clipped = __CLIP_HOLD;
+		} else if (__clipped > 0) {
+			__clipped -= 1;
+		}
+		__sum = 0;
+		__count = 0;
+		__peak = 0;
+		__draw();
+	};
+
+	var __percent = function(db) {
+		return Math.max(0, Math.min(100, (db - __FLOOR) / -__FLOOR * 100));
+	};
+
+	var __draw = function() {
+		let percent = __percent(__level_db);
+		let label = "";
+		if (__clipped > 0) {
+			label = "Clipping!";
+		} else if (percent > 0) {
+			label = `${Math.round(__level_db)} dB`;
+		}
+		tools.progress.setValue($("stream-mic-level-progress"), label, percent);
+	};
+}

--- a/web/share/js/kvm/stream_janus.js
+++ b/web/share/js/kvm/stream_janus.js
@@ -24,6 +24,7 @@
 
 
 import {tools, $} from "../tools.js";
+import {MicLevel} from "./mic_level.js";
 import {wm} from "../wm.js";
 
 
@@ -54,6 +55,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	var __has_mic = false;
 	var __use_mic = null;
 	var __use_mic_raw = false;
+	var __mic_level = new MicLevel();
 
 	var __has_camera = false;
 	var __use_camera = null;
@@ -72,6 +74,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 		tools.feature.setEnabled($("stream-audio"), false);
 		tools.feature.setEnabled($("stream-mic"), false);
 		tools.feature.setEnabled($("stream-mic-raw"), false);
+		tools.feature.setEnabled($("stream-mic-level"), false);
 		tools.feature.setEnabled($("stream-camera"), false);
 	};
 
@@ -326,6 +329,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	};
 
 	var __destroyJanus = function() {
+		__mic_level.detach();
 		if (__janus !== null) {
 			__janus.destroy();
 		}
@@ -422,6 +426,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 						tools.feature.setEnabled($("stream-audio"), (__has_audio = f.audio));
 						tools.feature.setEnabled($("stream-mic"), (__has_mic = f.mic));
 						tools.feature.setEnabled($("stream-mic-raw"), __has_mic);
+						tools.feature.setEnabled($("stream-mic-level"), __has_mic);
 						tools.feature.setEnabled($("stream-camera"), (__has_camera = (f.camera && f.camera.enabled)));
 						tools.feature.setEnabled($("stream-multimedia"), (__has_audio || __has_mic || __has_camera));
 						__ice = f.ice;
@@ -556,6 +561,14 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 			},
 
 			"onlocaltrack": function(track, added) {
+				if (track.kind === "audio") {
+					// The microphone is captured by Janus, so the meter just listens to it
+					if (added) {
+						__mic_level.attach(track);
+					} else {
+						__mic_level.detach();
+					}
+				}
 				// https://bugzilla.mozilla.org/show_bug.cgi?id=1831521
 				if (added && track.kind === "video") {
 					if ("contentHint" in track) { // WebKit

--- a/web/share/js/kvm/stream_media.js
+++ b/web/share/js/kvm/stream_media.js
@@ -55,6 +55,7 @@ export function MediaStreamer(__setActive, __setInactive, __setInfo, __watchHook
 		tools.feature.setEnabled($("stream-audio"), false);
 		tools.feature.setEnabled($("stream-mic"), false);
 		tools.feature.setEnabled($("stream-mic-raw"), false);
+		tools.feature.setEnabled($("stream-mic-level"), false);
 		tools.feature.setEnabled($("stream-camera"), false);
 	};
 

--- a/web/share/js/kvm/stream_mjpeg.js
+++ b/web/share/js/kvm/stream_mjpeg.js
@@ -46,6 +46,7 @@ export function MjpegStreamer(__setActive, __setInactive, __setInfo, __watchHook
 		tools.feature.setEnabled($("stream-audio"), false);
 		tools.feature.setEnabled($("stream-mic"), false);
 		tools.feature.setEnabled($("stream-mic-raw"), false);
+		tools.feature.setEnabled($("stream-mic-level"), false);
 		tools.feature.setEnabled($("stream-camera"), false);
 	};
 


### PR DESCRIPTION
Split out of #241 as asked.

There is no way to tell whether the host is receiving anything from the microphone without
checking the sound settings on the host itself. A muted OS input, a device with the gain at zero
and a working microphone all look the same in the menu.

The meter shows the level of the track that is actually being sent, after all the browser's
processing. The microphone is captured by Janus, so the meter only listens to the local track
from `onlocaltrack` and never opens the device itself. It reuses the existing progress widget,
so there is no new CSS and no new variables.

Tested in Chrome against a synthetic track: -15 dB at amplitude 0.25, -37 dB at 0.02,
`Clipping!` at 1.0, and the bar clears when the track goes away.

It touches the same few lines of the features handler as #241, so whichever goes in second needs
a trivial rebase.

<img width="527" height="192" alt="Screenshot 2026-08-20 at 15 44 54" src="https://github.com/user-attachments/assets/2225ae30-d595-49f0-8acf-3e7a317ff012" />