### PR TITLE
otg: configurable camera resolution and isochronous bandwidth (1080p opt-in)

### DIFF
--- a/kvmd/apps/_scheme.py
+++ b/kvmd/apps/_scheme.py
@@ -590,6 +590,10 @@ def make_config_scheme() -> dict:
                     "start":   Option(True,  type=valid_bool),
                     "safe":    Option(False, type=valid_bool),
                     "resolution": Option("1280x720", type=valid_stream_resolution),
+                    "streaming": {
+                        "maxpacket": Option(1024, type=valid_number.mk(min=1, max=3072)),
+                        "interval":  Option(4,    type=valid_number.mk(min=1, max=16)),
+                    },
                     "controls": {
                         "ct_mask": Option(0x00000E, type=valid_number.mk(min=0, max=0xFFFFFF)),
                         "pu_mask": Option(0x175B,   type=valid_number.mk(min=0, max=0xFFFF)),

--- a/kvmd/apps/_scheme.py
+++ b/kvmd/apps/_scheme.py
@@ -589,6 +589,7 @@ def make_config_scheme() -> dict:
                     "enabled": Option(False, type=valid_bool),
                     "start":   Option(True,  type=valid_bool),
                     "safe":    Option(False, type=valid_bool),
+                    "resolution": Option("1280x720", type=valid_stream_resolution),
                     "controls": {
                         "ct_mask": Option(0x00000E, type=valid_number.mk(min=0, max=0xFFFFFF)),
                         "pu_mask": Option(0x175B,   type=valid_number.mk(min=0, max=0xFFFF)),

--- a/kvmd/apps/otg/__init__.py
+++ b/kvmd/apps/otg/__init__.py
@@ -119,11 +119,12 @@ class _GadgetConfig:
 
         _mkdir(meta_path)
 
-    def add_camera(  # pylint: disable=too-many-locals
+    def add_camera(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
         self,
         starter: list[str],
         start: bool,
         safe: bool,
+        resolution: str,
         ct_mask: int,
         pu_mask: int,
     ) -> None:
@@ -158,9 +159,14 @@ class _GadgetConfig:
         func = "uvc.usb0"
         func_path = self.__create_function(func)
 
+        def interval(fps: int) -> int:
+            return math.floor(1 / fps * 10_000_000)  # 30 -> 333333, 100ns units
+
         _mkdir(join(func_path, "streaming/mjpeg/m"))
-        for (width, height, framerates) in [  # TODO: Make it configurable
-            # (1920, 1080, [30, 24, 20, 15, 10, 5]),
+        index = 0
+        default_index = 0
+        for (width, height, framerates) in [
+            (1920, 1080, [30, 24, 20, 15, 10, 5]),
             (1280, 720,  [30, 24, 20, 15, 10, 5]),
             (1024, 768,  [30, 24, 20, 15, 10, 5]),
             (1024, 576,  [30, 24, 20, 15, 10, 5]),
@@ -178,15 +184,27 @@ class _GadgetConfig:
         ]:
             if not framerates or (safe and width > 640):
                 continue
+            index += 1
+            if f"{width}x{height}" == resolution:
+                default_index = index
             fmt_path = join(func_path, f"streaming/mjpeg/m/{width}x{height}")
             _mkdir(fmt_path)
             _write(join(fmt_path, "wWidth"), width)
             _write(join(fmt_path, "wHeight"), height)
             _write(join(fmt_path, "dwMaxVideoFrameBufferSize"), width * height)  # Should be fine
             _write(join(fmt_path, "dwFrameInterval"), "\n".join(
-                str(math.floor(1 / fps * 10_000_000))  # 30 -> 333333, 100ns units
+                str(interval(fps))
                 for fps in framerates
             ))
+            # Without these the kernel keeps its own defaults, which describe
+            # a 640x360 frame at 15 FPS no matter what we have configured
+            _write(join(fmt_path, "dwDefaultFrameInterval"), interval(max(framerates)))
+            _write(join(fmt_path, "dwMinBitRate"), width * height * min(framerates))  # ~1 bit per pixel
+            _write(join(fmt_path, "dwMaxBitRate"), width * height * max(framerates) * 2)
+        if default_index > 0:
+            _write(join(func_path, "streaming/mjpeg/m/bDefaultFrameIndex"), default_index)
+        elif not safe:  # The safe mode may drop the requested resolution, keep the kernel's default then
+            raise RuntimeError(f"No such OTG camera resolution: {resolution}")
 
         path = join(func_path, "streaming/header/h")
         _mkdir(path)
@@ -471,7 +489,10 @@ def _cmd_start(config: Section) -> None:  # pylint: disable=too-many-statements,
 
     if cod.camera.enabled:
         logger.info("===== Camera =====")
-        gc.add_camera(["camera"], cod.camera.start, cod.camera.safe, cod.camera.controls.ct_mask, cod.camera.controls.pu_mask)
+        gc.add_camera(
+            ["camera"], cod.camera.start, cod.camera.safe, cod.camera.resolution,
+            cod.camera.controls.ct_mask, cod.camera.controls.pu_mask,
+        )
 
     logger.info("===== Preparing complete =====")
 

--- a/kvmd/apps/otg/__init__.py
+++ b/kvmd/apps/otg/__init__.py
@@ -125,6 +125,8 @@ class _GadgetConfig:
         start: bool,
         safe: bool,
         resolution: str,
+        streaming_maxpacket: int,
+        streaming_interval: int,
         ct_mask: int,
         pu_mask: int,
     ) -> None:
@@ -223,8 +225,12 @@ class _GadgetConfig:
         ]:
             _write(join(func_path, path), "\n".join(map(str, mask.to_bytes(mask_len, "little"))))
 
-        _write(join(func_path, "streaming_maxpacket"), 1024)
-        _write(join(func_path, "streaming_interval"), 4)
+        # The isochronous budget is maxpacket bytes every 2^(interval-1) microframes (125us),
+        # so the defaults give ~1 MB/s, enough for 720p with a moderate picture. 1080p needs
+        # interval 1 (8 MB/s with 1024), at the price of the kernel having to serve
+        # the endpoint every single microframe.
+        _write(join(func_path, "streaming_maxpacket"), streaming_maxpacket)
+        _write(join(func_path, "streaming_interval"), streaming_interval)
 
         self.__setup_function(func, "Camera", 2, starter, start)  # TODO: Check eps number
 
@@ -491,6 +497,7 @@ def _cmd_start(config: Section) -> None:  # pylint: disable=too-many-statements,
         logger.info("===== Camera =====")
         gc.add_camera(
             ["camera"], cod.camera.start, cod.camera.safe, cod.camera.resolution,
+            cod.camera.streaming.maxpacket, cod.camera.streaming.interval,
             cod.camera.controls.ct_mask, cod.camera.controls.pu_mask,
         )
 

--- a/web/kvm/index.html
+++ b/web/kvm/index.html
@@ -451,6 +451,7 @@
                 <td style="width: 150px;">
                   <select class="small" id="stream-camera-selector" style="width: 100%;" disabled></select>
                 </td>
+                <td class="value" id="stream-camera-resolution" title="What the remote host actually receives"></td>
               </tr>
             </table>
           </div>

--- a/web/kvm/navbar-system.pug
+++ b/web/kvm/navbar-system.pug
@@ -140,6 +140,7 @@ li.right#system-dropdown
 					td Camera:
 					td #[+menu_switch("stream-camera-switch", false, false)]
 					td(style="width: 150px;") #[select.small#stream-camera-selector(style="width: 100%;" disabled)]
+					td.value#stream-camera-resolution(title="What the remote host actually receives")
 
 		hr
 

--- a/web/share/js/kvm/stream_janus.js
+++ b/web/share/js/kvm/stream_janus.js
@@ -61,6 +61,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	var __has_camera = false;
 	var __use_camera = null;
 	var __camera_req = null;
+	var __camera_relaxed = null; // The resolution the selected webcam refused to capture exactly
 	var __camera_track = null;
 	var __camera_frames = null;
 
@@ -183,6 +184,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 			if (camera) {
 				__refillDevices("camera", camera, function(id) {
 					__use_camera = id;
+					__camera_relaxed = null;
 					if (__has_camera) {
 						__destroyJanus();
 					}
@@ -491,11 +493,20 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 						// Помогают пляски в onlocaltrack.
 						let w = __camera_req.resolution.width;
 						let h = __camera_req.resolution.height;
-						camera = {
-							"width": {"min": w, "ideal": w, "max": w},
-							"height": {"min": h, "ideal": h, "max": h},
-							"frameRate": {"ideal": __camera_req.fps, "max": 30},
-						};
+						if (__camera_relaxed === `${w}x${h}`) {
+							// The webcam can't do exactly what the guest asked for, take the closest mode it has
+							camera = {
+								"width": {"ideal": w},
+								"height": {"ideal": h},
+								"frameRate": {"ideal": __camera_req.fps, "max": 30},
+							};
+						} else {
+							camera = {
+								"width": {"min": w, "ideal": w, "max": w},
+								"height": {"min": h, "ideal": h, "max": h},
+								"frameRate": {"ideal": __camera_req.fps, "max": 30},
+							};
+						}
 						if (__use_camera !== ".__default__") {
 							camera["deviceId"] = {"exact": __use_camera};
 						}
@@ -528,11 +539,19 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 							let restart = function() {
 								try {
 									if (error?.name === "OverconstrainedError") {
-										if (__has_mic && __use_mic) {
-											self.setMicDevice(".__default__", true);
-										}
-										if (__has_camera && __use_camera) {
-											self.setCameraDevice(".__default__", true);
+										let res = (__camera_req ? `${__camera_req.resolution.width}x${__camera_req.resolution.height}` : null);
+										if (res !== null && __camera_relaxed !== res && !["deviceId", "groupId"].includes(error.constraint)) {
+											// Retry with the resolution as a wish instead of a demand before giving up on the device,
+											// otherwise a webcam without this mode keeps failing and restarting forever
+											__logInfo(`The webcam refused ${res} (${error.constraint || "unknown constraint"}), relaxing ...`);
+											__camera_relaxed = res;
+										} else {
+											if (__has_mic && __use_mic) {
+												self.setMicDevice(".__default__", true);
+											}
+											if (__has_camera && __use_camera) {
+												self.setCameraDevice(".__default__", true);
+											}
 										}
 									}
 								} finally {
@@ -570,12 +589,18 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 					if (__handle?.webrtcStuff?.pc) {
 						for (let sender of __handle.webrtcStuff.pc.getSenders()) {
 							if (sender.track === track) {
-								if (tools.browser.is_mobile) {
+								let res = __camera_req.resolution;
+								let st = track.getSettings();
+								let fits = (st.width === res.width && st.height === res.height);
+								if (tools.browser.is_mobile || (__camera_relaxed === `${res.width}x${res.height}` && !fits)) {
+									// The guest has been promised exactly this resolution and the pipeline
+									// drops anything else, so rotate or scale whatever the webcam gave us
 									try {
-										__logInfo("Patching camera track for auto-rotate ...");
-										let s_track = _makeSmartCameraTrack(track, __camera_req.resolution);
+										__logInfo(`Patching camera track for auto-rotate/scale (${st.width}x${st.height} -> ${res.width}x${res.height}) ...`);
+										let s_track = _makeSmartCameraTrack(track, res);
 										s_track.contentHint = "detail";
 										sender.replaceTrack(s_track);
+										track = s_track;
 									} catch (ex) {
 										__logError("Can't patch camera track:", ex);
 									}
@@ -891,7 +916,7 @@ function _makeSmartCameraTrack(track, res) {
 				}
 			}
 			this.__ts = performance.now();
-			if (this.__el_video.videoWidth == res.width) {
+			if (this.__el_video.videoWidth == res.width && this.__el_video.videoHeight == res.height) {
 				this.__ctx.drawImage(this.__el_video, 0, 0);
 			} else if (this.__el_video.videoWidth == res.height) {
 				const sw = this.__el_video.videoWidth; // Source
@@ -908,6 +933,19 @@ function _makeSmartCameraTrack(track, res) {
 					sw, th, // Source size
 					0, 0, // Dest (x,y)
 					dw, dh); // Dest size
+			} else {
+				// Some other mode of the webcam: scale it to fill the frame, cropping the excess
+				const sw = this.__el_video.videoWidth;
+				const sh = this.__el_video.videoHeight;
+				const scale = Math.max(res.width / sw, res.height / sh);
+				const cw = res.width / scale; // Cropped source size
+				const ch = res.height / scale;
+				this.__ctx.drawImage(
+					this.__el_video,
+					(sw - cw) / 2, (sh - ch) / 2, // Source (x,y)
+					cw, ch, // Source size
+					0, 0, // Dest (x,y)
+					res.width, res.height); // Dest size
 			}
 			controller.enqueue(new VideoFrame(canvas, {"timestamp": this.__ts}));
 		},

--- a/web/share/js/kvm/stream_janus.js
+++ b/web/share/js/kvm/stream_janus.js
@@ -579,9 +579,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 
 								// Firefox doesn't support contentHint but there is another hack
 								//   - https://bugzilla.mozilla.org/show_bug.cgi?id=1831521
-								let params = sender.getParameters();
-								params.degradationPreference = "maintain-resolution";
-								sender.setParameters(params);
+								__tuneVideoSender(sender, 10);
 								break;
 							}
 						}
@@ -705,6 +703,27 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 
 	var __isOnline = function() {
 		return !!(__state && __state.source.online);
+	};
+
+	var __tuneVideoSender = function(sender, attempts) {
+		// Until the negotiation is complete getParameters() returns no encodings,
+		// and setParameters() rejects any change of their number, so retry a bit
+		let params = sender.getParameters();
+		if (!params.encodings || params.encodings.length === 0) {
+			if (attempts > 0 && sender.track) {
+				setTimeout(() => __tuneVideoSender(sender, attempts - 1), 500);
+			}
+			return;
+		}
+		params.degradationPreference = "maintain-resolution";
+		// The default cap (2.5 Mbps on Chrome, ~1 Mbps on Firefox) starves 1080p30
+		// and the webcam looks like upscaled SD no matter the resolution
+		params.encodings[0].maxBitrate = 8 * 1000 * 1000;
+		sender.setParameters(params).then(function() {
+			__logInfo("Installed degradationPreference=maintain-resolution, maxBitrate:", sender.track);
+		}).catch(function(ex) {
+			__logError("Can't tune the video sender:", ex);
+		});
 	};
 
 	var __sendWatch = function() {

--- a/web/share/js/kvm/stream_janus.js
+++ b/web/share/js/kvm/stream_janus.js
@@ -61,6 +61,8 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	var __has_camera = false;
 	var __use_camera = null;
 	var __camera_req = null;
+	var __camera_track = null;
+	var __camera_frames = null;
 
 	var __orient = 0;
 
@@ -254,6 +256,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	self.stopStream = function() {
 		__fix_zero_h264_gop = null;
 		__stop = true;
+		__setCameraTrack(null);
 		__destroyJanus();
 		if (__resize_listener_installed) {
 			$("stream-video").removeEventListener("resize", __videoResizeHandler);
@@ -334,6 +337,7 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 	var __destroyJanus = function() {
 		__audio_vu.detach();
 		__mic_vu.detach();
+		__setCameraTrack(null);
 		if (__janus !== null) {
 			__janus.destroy();
 		}
@@ -585,6 +589,9 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 						}
 					}
 				}
+				if (track.kind === "video") {
+					__setCameraTrack(added ? track : null);
+				}
 				if (track.kind === "audio") {
 					if (added) {
 						__mic_vu.attach(track);
@@ -698,11 +705,76 @@ export function JanusStreamer(__setActive, __setInactive, __setInfo, __watchHook
 				}
 			}
 			__setInfo(true, __isOnline(), info);
+			__updateCameraInfo();
 		}
 	};
 
 	var __isOnline = function() {
 		return !!(__state && __state.source.online);
+	};
+
+	var __setCameraTrack = function(track) {
+		__camera_track = track;
+		__camera_frames = null;
+		if (track === null) {
+			$("stream-camera-resolution").textContent = "";
+		} else {
+			__updateCameraInfo();
+		}
+	};
+
+	var __updateCameraInfo = function() {
+		let track = __camera_track;
+		if (track === null) {
+			return;
+		}
+		let sender = (__handle?.webrtcStuff?.pc?.getSenders() || []).find(item => (item.track === track));
+		if (sender === undefined) {
+			return;
+		}
+		sender.getStats().then(function(stats) {
+			if (__camera_track !== track) {
+				return; // The camera was switched off while we were waiting for the stats
+			}
+			let rtp = null;
+			stats.forEach(function(report) {
+				if (report.type === "outbound-rtp" && report.kind === "video") {
+					rtp = report;
+				}
+			});
+			// Prefer what is actually being encoded and sent: WebRTC can downscale
+			// the capture, and Firefox reports incomplete settings for some devices
+			let st = track.getSettings();
+			let width = (rtp?.frameWidth || st.width || __camera_req?.resolution.width || 0);
+			let height = (rtp?.frameHeight || st.height || __camera_req?.resolution.height || 0);
+			let fps = __getCameraFps(rtp);
+			$("stream-camera-resolution").textContent = (
+				width > 0 && height > 0
+					? `${width}x${height}` + (fps === null ? "" : `@${fps}`)
+					: ""
+			);
+		}).catch(function(ex) {
+			__logError("Can't get the camera stats:", ex);
+		});
+	};
+
+	var __getCameraFps = function(rtp) {
+		if (rtp === null) {
+			return null;
+		}
+		if (rtp.framesPerSecond !== undefined) {
+			return Math.round(rtp.framesPerSecond);
+		}
+		// Firefox doesn't count the frame rate for us, so measure it between the polls
+		if (rtp.framesSent === undefined) {
+			return null;
+		}
+		let prev = __camera_frames;
+		__camera_frames = {"frames": rtp.framesSent, "ts": rtp.timestamp};
+		if (prev === null || rtp.timestamp <= prev.ts) {
+			return null;
+		}
+		return Math.round((rtp.framesSent - prev.frames) * 1000 / (rtp.timestamp - prev.ts));
 	};
 
 	var __tuneVideoSender = function(sender, attempts) {


### PR DESCRIPTION
Rebased onto 4.213. The one-liner is gone, this is now a proper opt-in for 1080p that keeps the stock behaviour untouched by default.

### What changed

- **`otg.devices.camera.resolution`** (default `1280x720`) picks which frame the host is offered as its default, via `bDefaultFrameIndex`. All frames stay advertised, so a guest app that wants 640x480 still gets it; only the default moves. It works together with `safe`: when safe mode filters the requested resolution out, the kernel default is kept. A typo fails loudly at gadget setup instead of silently falling back.
- 1920x1080 is uncommented in the frame table. It only becomes the default when asked for.
- The frames now also get `dwDefaultFrameInterval`, `dwMinBitRate` and `dwMaxBitRate`. Without them the kernel keeps its own defaults, which describe a 640x360 frame at 15 FPS for every entry, no matter what was configured.
- **`otg.devices.camera.streaming.maxpacket` / `interval`** with the current 1024/4 as defaults. Those give about 1 MB/s of isochronous budget (maxpacket bytes per 2^(interval-1) microframes). I measured stock 4.213 on a V4 Mini with a plain webcam: 720p comes through at **15.7 fps** with 62 KB frames, 0.95 MB/s, right at that cap. So 720p30 is not reachable with the defaults either, and a detailed picture makes it worse; that is the "large frames don't fit into the time slot" effect from the comments above. A device that is set up per the docs (`isolcpus`, pinned UDC interrupt) can opt into interval 1:

  ```yaml
  otg:
      devices:
          camera:
              enabled: true
              resolution: 1920x1080
              streaming:
                  maxpacket: 1024
                  interval: 1
  ```
- Web: the sender tuning in `onlocaltrack` ran before the WebRTC negotiation finished, when `getParameters()` returns no encodings, so `setParameters()` was rejected and even the existing `degradationPreference` never applied. It now retries until the encodings exist and also raises the sender bitrate cap to 8 Mbps, because the browser default (2.5 Mbps on Chrome, about 1 Mbps on Firefox) starves 1080p30 and the camera looks like upscaled SD whatever the resolution says.
- Web: a webcam that does not have the exact mode the guest asked for used to fail with `OverconstrainedError`, and the handler only reset the device to the default one, which fails the same way, so the page kept creating and destroying a Janus session every second while the guest saw black. Now the constraints are relaxed to `ideal` on the first such error, and since the janus plugin drops frames of any other size than the one the guest expects, the captured track is scaled through the same canvas the mobile auto-rotate uses. A 720p webcam gives a soft 1080p picture instead of nothing.
- Web: the camera row in the System menu shows what is actually being sent, like `1920x1080@30`, taken from the `outbound-rtp` stats.

### On the missed requests

I looked at where they come from, since that is what made 1080p unstable. dwc2 on the CM4 runs in buffer DMA mode, so an isochronous IN endpoint gets exactly one request per (micro)frame and the next one is started from the completion interrupt. Whenever that interrupt is late, or the DMA has not filled the TX FIFO before the IN token arrives, the request comes back with `-ENODATA` and nothing was sent. Patch 1301 in linux-rpi-pikvm maps that onto `UVC_QUEUE_DROP_INCOMPLETE`, so a single missed 125 us window throws away the whole video frame. With bInterval 1 there are 8000 of those windows a second, which is why the misses "add up until the stream breaks", and why larger frames make it worse: more windows carry data, so more misses hit a payload instead of a harmless zero-length packet.

Measured on the V4 Mini (6.12.105-1-rpi, ucamera 0.5), 1080p at 2048/1 with the stock module: **7.5 fps at the gadget, 25 misses a second**, every one of them a lost frame.

For MJPEG the host does not care which microframe a payload arrives in, it just reassembles payloads until the FID bit toggles. So the payload can simply be sent again in the next window instead of being dropped. The kernel side is pikvm/packages#16, a lenient mode for isochronous IN in dwc2 (buffer DMA): a transfer that missed its frame is left armed or started late and goes out in the next possible (micro)frame, the way dwc2 behaved before the 2021 "Fix ISOC flow" commit, instead of being aborted with a 200 us poll in the interrupt handler and reported as `-ENODATA`. Module parameter `dwc2.isoc_in_lenient`, on by default. With it the same 1080p stream shows zero missed windows, whole frames, no corruption; the remaining fps limit is the webcam. This PR does not depend on it, the defaults stay 1024/4 either way; the two together are what makes 1080p work.

### Testing

V4 Mini, kvmd 4.213 with this branch, kernel 6.12.105-1-rpi, ucamera 0.5, macOS guest, Firefox and Chromium clients. The guest picks 1920x1080 by default, the resolution readout follows the actual stream, and a 720p-only webcam ends up as a scaled 1080p stream instead of a black picture. The numbers above are from `strace` on ucamera's `VIDIOC_DQBUF` and the `missed xfer` lines in dmesg.

